### PR TITLE
Remove dependency on 'collection'

### DIFF
--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -4,7 +4,7 @@
 
 library args.src.arg_parser;
 
-import 'package:collection/wrappers.dart';
+import 'dart:collection';
 
 import 'arg_results.dart';
 import 'option.dart';

--- a/lib/src/arg_results.dart
+++ b/lib/src/arg_results.dart
@@ -4,7 +4,7 @@
 
 library args.src.arg_results;
 
-import 'package:collection/wrappers.dart';
+import 'dart:collection';
 
 import 'arg_parser.dart';
 

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -4,7 +4,7 @@
 
 library args.src.option;
 
-import 'package:collection/wrappers.dart';
+import 'dart:collection';
 
 /// Creates a new [Option].
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,6 @@ description: >
  Library for defining parsers for parsing raw command-line arguments into
  a set of options and values using GNU and POSIX style options.
 
-dependencies:
-  collection: ">=0.9.0 <2.0.0"
 dev_dependencies:
   unittest: ">=0.11.5 <0.12.0"
 environment:


### PR DESCRIPTION
`args` was using `package:collection/wrappers.dart` for creating unmodifiable collection views, but this functionality is built directly into the SDK in `dart:collection`

This would be a breaking change, because of transitive dependencies.