### PR TITLE
Make Command.argResults and Command.globalResults public to facilitate testing Command subclasses with mock ArgResults.

### DIFF
--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -158,8 +158,8 @@ Run "$executableName help <command>" for more information about a command.''';
         // Step into the command.
         argResults = argResults.command;
         command = commands[argResults.name];
-        command._globalResults = topLevelResults;
-        command._argResults = argResults;
+        command.globalResults = topLevelResults;
+        command.argResults = argResults;
         commands = command._subcommands;
         commandString += " ${argResults.name}";
 
@@ -231,12 +231,16 @@ abstract class Command {
   ///
   /// This will be `null` until just before [Command.run] is called.
   ArgResults get globalResults => _globalResults;
+  /// The setter is intended for use during testing, to facilitate mocking.
+  void set globalResults(ArgResults results) { _globalResults = results; }
   ArgResults _globalResults;
 
   /// The parsed argument results for this command.
   ///
   /// This will be `null` until just before [Command.run] is called.
   ArgResults get argResults => _argResults;
+  /// The setter is intended for use during testing, to facilitate mocking.
+  void set argResults(ArgResults results) { _argResults = results; }
   ArgResults _argResults;
 
   /// The argument parser for this command.


### PR DESCRIPTION
This makes it possible to write Command tests that look like this:

```
import 'dart:async';

import 'package:args/args.dart';
import 'package:args/command_runner.dart';
import 'package:mockito/mockito.dart';
import 'package:test/test.dart';

class ExampleCommand extends Command {
  final name = 'install';
  final description = 'Amazing example!';
  ExampleCommand();

  @override
  Future<int> run() async {
    if (argResults['bad-option'] == true) {
      return 2;
    }

    if (argResults['carefully-checked-option'] == true) {
      return 0;
    }

    print('You need to specify an option to use $name!');
    return 1;
  }
}

class MockArgResults extends Mock implements ArgResults {}

main() => defineTests();

defineTests() {
  group('example', () {
    test('returns 0 when called with carefully-checked-option', () {
      ExampleCommand command = new ExampleCommand();

      MockArgResults results = new MockArgResults();
      when(results['carefully-checked-option']).thenReturn(true);
      when(results['bad-option']).thenReturn(false);
      command.argResults = results;
      command
          .run()
          .then((int code) => expect(code, equals(0)));
    });
  });
}
```

This seems like the natural way to test commands, rather than having to pass a List&lt;String&gt; to a CommandRunner.

What do you think?