### PR TITLE
replace deprecated getUsage() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,10 +363,10 @@ parser.addOption('arch', help: 'The architecture to compile for',
     });
 ```
 
-To display the help, use the [getUsage()][getUsage] method:
+To display the help, use the [usage][usage] getter:
 
 ```dart
-print(parser.getUsage());
+print(parser.usage);
 ```
 
 The resulting string looks something like this:


### PR DESCRIPTION
Noticed this on the docs, but the README hadn't been updated yet.
```
@Deprecated("Replaced with get usage. getUsage() will be removed in args 1.0")
String getUsage() => usage;
```