### PR TITLE
Print the proper usage in CommandRunner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.13.6
+
+* `ArgParser.parse()` now throws an `ArgParserException`, which implements
+  `FormatException` and has a field that lists the commands that were parsed.
+
+* If `CommandRunner.run()` encounters a parse error for a subcommand, it now
+  prints the subcommand's usage rather than the global usage.
+
 ## 0.13.5
 
 * Allow `CommandRunner.argParser` and `Command.argParser` to be overridden in

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ The default value for non-flag options can be any string. For flags, it must
 be a `bool`.
 
 To validate a non-flag option, you can use the `allowed` parameter to provide an
-allowed set of values. When you do, the parser throws a [FormatException] if the
-value for an option is not in the allowed set. Here's an example of specifying
-allowed values:
+allowed set of values. When you do, the parser throws an
+[`ArgParserException`][ArgParserException] if the value for an option is not in
+the allowed set. Here's an example of specifying allowed values:
+
+[ArgParserException]: https://www.dartdocs.org/documentation/args/latest/args/ArgParserException-class.html
 
 ```dart
 parser.addOption('mode', allowed: ['debug', 'release']);

--- a/lib/args.dart
+++ b/lib/args.dart
@@ -3,5 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/arg_parser.dart';
+export 'src/arg_parser_exception.dart';
 export 'src/arg_results.dart' hide newArgResults;
 export 'src/option.dart' hide newOption;

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An exception thrown by [ArgParser].
+class ArgParserException extends FormatException {
+  /// The command(s) that were parsed before discovering the error.
+  ///
+  /// This will be empty if the error was on the root parser.
+  final List<String> commands;
+
+  ArgParserException(String message, [Iterable<String> commands])
+      : commands = commands == null
+            ? const []
+            : new List.unmodifiable(commands),
+        super(message);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 0.13.5
+version: 0.13.6
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/args
 description: >

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -246,6 +246,27 @@ Run "test help" to see global options.
 """));
       });
     });
+
+    group("with an invalid argument", () {
+      test("at the root throws the root usage", () {
+        expect(runner.run(["--asdf"]), throwsUsageException(
+            'Could not find an option named "asdf".',
+            '$_DEFAULT_USAGE'));
+      });
+
+      test("for a command throws the command usage", () {
+        var command = new FooCommand();
+        runner.addCommand(command);
+
+        expect(runner.run(["foo", "--asdf"]), throwsUsageException(
+            'Could not find an option named "asdf".',
+            """
+Usage: test foo [arguments]
+-h, --help    Print this usage information.
+
+Run "test help" to see global options."""));
+      });
+    });
   });
 
   group("with a footer", () {


### PR DESCRIPTION
This now prints the usage for the command that failed to parse, rather
than always printing the root usage.

Closes #52