### PR TITLE
Support command return value forwarding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.13.7
+
+* Add explicit support for forwarding the value returned by `Command.run()` to
+  `CommandRunner.run()`. This worked unintentionally prior to 0.13.6+1.
+
+* Add type arguments to `CommandRunner` and `Command` to indicate the return
+  values of the `run()` functions.
+
 ## 0.13.6+1
 
 * When a `CommandRunner` is passed `--help` before any commands, it now prints

--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -7,17 +7,17 @@ import '../command_runner.dart';
 /// The built-in help command that's added to every [CommandRunner].
 ///
 /// This command displays help information for the various subcommands.
-class HelpCommand extends Command {
+class HelpCommand<T> extends Command<T> {
   final name = "help";
   String get description =>
       "Display help information for ${runner.executableName}.";
   String get invocation => "${runner.executableName} help [command]";
 
-  void run() {
+  T run() {
     // Show the default help if no command was specified.
     if (argResults.rest.isEmpty) {
       runner.printUsage();
-      return;
+      return null;
     }
 
     // Walk the command tree to show help for the selected command or
@@ -47,5 +47,6 @@ class HelpCommand extends Command {
     }
 
     command.printUsage();
+    return null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 0.13.6+1
+version: 0.13.7
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/args
 description: >

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -161,6 +161,22 @@ Run "test help <command>" for more information about a command."""));
       }), completes);
     });
 
+    test("runs a command with a return value", () {
+      var runner = new CommandRunner<int>("test", "");
+      var command = new ValueCommand();
+      runner.addCommand(command);
+
+      expect(runner.run(["foo"]), completion(equals(12)));
+    });
+
+    test("runs a command with an asynchronous return value", () {
+      var runner = new CommandRunner<String>("test", "");
+      var command = new AsyncValueCommand();
+      runner.addCommand(command);
+
+      expect(runner.run(["foo"]), completion(equals("hi")));
+    });
+
     test("runs a hidden comand", () {
       var command = new HiddenCommand();
       runner.addCommand(command);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -27,6 +27,22 @@ class FooCommand extends Command {
   }
 }
 
+class ValueCommand extends Command<int> {
+  final name = "foo";
+  final description = "Return a value.";
+  final takesArguments = false;
+
+  int run() => 12;
+}
+
+class AsyncValueCommand extends Command<String> {
+  final name = "foo";
+  final description = "Return a future.";
+  final takesArguments = false;
+
+  Future<String> run() async => "hi";
+}
+
 class MultilineCommand extends Command {
   var hasRun = false;
 


### PR DESCRIPTION
This was unintentionally supported prior to 0.13.6+1. This re-adds
support, documents and tests it, and adds type annotations to make it
type-safe.

Closes #57
Closes #58