### PR TITLE
Add support for testing in the VM on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: dart
+dart:
+  - dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: dart
 dart:
   - dev
+  - stable

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/dart-lang/args.svg?branch=master)](https://travis-ci.org/dart-lang/args)
+
 Parses raw command-line arguments into a set of options and values.
 
 This library supports [GNU][] and [POSIX][] style options, and it works


### PR DESCRIPTION
Unclear if this adds value. My thinking is trying to make this
(and eventually other) dart packages feel more appealing to
the casual non-google contributor in part by helping to know
if the package is working for non-google configs.

I've run into the trouble with public Github Dart packages not
working for non-google configs before, and my thought is
Travis might be one way to help with that.

Thoughts welcome!  Happy to discard this if not helpful.

Someone with admin powers for dart-lang (like @kevmoo)
would have to flip the bit at:
https://travis-ci.org/dart-lang/args
to actually turn on testing.