### PR TITLE
Fix addMultiOption() and addOption(allowMultiple) usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+* Fix the way default values for multi-valued options are printed in argument
+  usage.
+
 ## 1.4.0
 
 * Deprecated `OptionType.FLAG`, `OptionType.SINGLE`, and `OptionType.MULTIPLE`

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -88,10 +88,20 @@ class Usage {
         newline();
       } else if (option.allowed != null) {
         write(2, buildAllowedList(option));
-      } else if (option.defaultsTo != null) {
-        if (option.isFlag && option.defaultsTo == true) {
+      } else if (option.isFlag) {
+        if (option.defaultsTo == true) {
           write(2, '(defaults to on)');
-        } else if (!option.isFlag) {
+        }
+      } else if (option.isMultiple) {
+        if (option.defaultsTo != null && option.defaultsTo.isNotEmpty) {
+          write(
+              2,
+              '(defaults to ' +
+                  option.defaultsTo.map((value) => '"$value"').join(', ') +
+                  ')');
+        }
+      } else {
+        if (option.defaultsTo != null) {
           write(2, '(defaults to "${option.defaultsTo}")');
         }
       }
@@ -217,13 +227,17 @@ class Usage {
   }
 
   String buildAllowedList(Option option) {
+    var isDefault = option.defaultsTo is List
+        ? option.defaultsTo.contains
+        : (value) => value == option.defaultsTo;
+
     var allowedBuffer = new StringBuffer();
     allowedBuffer.write('[');
-    bool first = true;
+    var first = true;
     for (var allowed in option.allowed) {
       if (!first) allowedBuffer.write(', ');
       allowedBuffer.write(allowed);
-      if (allowed == option.defaultsTo) {
+      if (isDefault(allowed)) {
         allowedBuffer.write(' (default)');
       }
       first = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 1.4.0
+version: 1.4.1
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/args
 description: >

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -91,22 +91,63 @@ void main() {
       var parser = new ArgParser();
       parser.addFlag('affirm', help: 'Should be on', defaultsTo: true);
       parser.addFlag('negate', help: 'Should be off', defaultsTo: false);
+      parser.addFlag('null', help: 'Should be null', defaultsTo: null);
 
       validateUsage(parser, '''
           --[no-]affirm    Should be on
                            (defaults to on)
 
           --[no-]negate    Should be off
+          --[no-]null      Should be null
           ''');
     });
 
     test('the default value for an option with no allowed list is shown', () {
       var parser = new ArgParser();
-      parser.addOption('any', help: 'Can be anything', defaultsTo: 'whatevs');
+      parser.addOption('single',
+          help: 'Can be anything', defaultsTo: 'whatevs');
+      parser.addMultiOption('multiple',
+          help: 'Can be anything', defaultsTo: ['whatevs']);
+      parser.addOption('allow-multi',
+          help: 'Can be anything', defaultsTo: 'whatevs', allowMultiple: true);
+
+      validateUsage(parser, '''
+          --single         Can be anything
+                           (defaults to "whatevs")
+
+          --multiple       Can be anything
+                           (defaults to "whatevs")
+
+          --allow-multi    Can be anything
+                           (defaults to "whatevs")
+          ''');
+    });
+
+    test('multiple default values for an option with no allowed list are shown',
+        () {
+      var parser = new ArgParser();
+      parser.addMultiOption('any',
+          help: 'Can be anything', defaultsTo: ['some', 'stuff']);
 
       validateUsage(parser, '''
           --any    Can be anything
-                   (defaults to "whatevs")
+                   (defaults to "some", "stuff")
+          ''');
+    });
+
+    test('no default values are shown for a multi option with an empty default',
+        () {
+      var parser = new ArgParser();
+      parser.addMultiOption('implicit', help: 'Implicit default');
+      parser
+          .addMultiOption('explicit', help: 'Explicit default', defaultsTo: []);
+      parser.addOption('allow-multi',
+          help: 'Implicit with allowMultiple', allowMultiple: true);
+
+      validateUsage(parser, '''
+          --implicit       Implicit default
+          --explicit       Explicit default
+          --allow-multi    Implicit with allowMultiple
           ''');
     });
 
@@ -142,6 +183,19 @@ void main() {
       validateUsage(parser, '''
           --suit    Like in cards
                     [spades, clubs (default), hearts, diamonds]
+          ''');
+    });
+
+    test('multiple defaults are highlighted in the allowed list', () {
+      var parser = new ArgParser();
+      parser.addMultiOption('suit',
+          help: 'Like in cards',
+          defaultsTo: ['clubs', 'diamonds'],
+          allowed: ['spades', 'clubs', 'hearts', 'diamonds']);
+
+      validateUsage(parser, '''
+          --suit    Like in cards
+                    [spades, clubs (default), hearts, diamonds (default)]
           ''');
     });
 


### PR DESCRIPTION
We were printing the option list, with square brackets, even for
options that didn't have a default.

Fixes dart-lang/test#774.