### PR TITLE
Add optional wrapping of text for usage messages.

### DIFF
--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -13,6 +13,7 @@ class AllowAnythingParser implements ArgParser {
   Map<String, ArgParser> get commands => const {};
   bool get allowTrailingOptions => false;
   bool get allowsAnything => true;
+  int get maxLineLength => null;
 
   ArgParser addCommand(String name, [ArgParser parser]) {
     throw new UnsupportedError(

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -30,6 +30,18 @@ class ArgParser {
   /// arguments.
   final bool allowTrailingOptions;
 
+  /// An optional maximum line length for [usage] messages.
+  ///
+  /// If specified, then help messages in the usage are wrapped at the given
+  /// column, after taking into account the width of the options. Will refuse to
+  /// wrap help text to less than 10 characters of help text per line if there
+  /// isn't enough space on the line. It preserves embedded newlines, and
+  /// attempts to wrap at whitespace breaks (although it will split words if
+  /// there is no whitespace at which to split).
+  ///
+  /// If null (the default), help messages are not wrapped.
+  final int maxLineLength;
+
   /// Whether or not this parser treats unrecognized options as non-option
   /// arguments.
   bool get allowsAnything => false;
@@ -40,9 +52,10 @@ class ArgParser {
   /// flags and options that appear after positional arguments. If it's `false`,
   /// the parser stops parsing as soon as it finds an argument that is neither
   /// an option nor a command.
-  factory ArgParser({bool allowTrailingOptions: true}) =>
+  factory ArgParser({bool allowTrailingOptions: true, int maxLineLength}) =>
       new ArgParser._(<String, Option>{}, <String, ArgParser>{},
-          allowTrailingOptions: allowTrailingOptions);
+          allowTrailingOptions: allowTrailingOptions,
+          maxLineLength: maxLineLength);
 
   /// Creates a new ArgParser that treats *all input* as non-option arguments.
   ///
@@ -53,7 +66,7 @@ class ArgParser {
   factory ArgParser.allowAnything() = AllowAnythingParser;
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
-      {bool allowTrailingOptions: true})
+      {bool allowTrailingOptions: true, this.maxLineLength})
       : this._options = options,
         this.options = new UnmodifiableMapView(options),
         this._commands = commands,
@@ -315,7 +328,10 @@ class ArgParser {
   /// Generates a string displaying usage information for the defined options.
   ///
   /// This is basically the help text shown on the command line.
-  String get usage => new Usage(_optionsAndSeparators).generate();
+  String get usage {
+    return new Usage(_optionsAndSeparators, maxLineLength: maxLineLength)
+        .generate();
+  }
 
   /// Get the default value for an option. Useful after parsing to test if the
   /// user specified something other than the default.

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -314,6 +314,102 @@ void main() {
           ''');
     });
 
+    test("help strings are not wrapped if maxLineLength is null", () {
+      var parser = new ArgParser(maxLineLength: null);
+      parser.addFlag('long',
+          help: 'The flag with a really long help text that will not '
+              'be wrapped.');
+      validateUsage(parser, '''
+          --[no-]long    The flag with a really long help text that will not be wrapped.
+          ''');
+    });
+
+    test("help strings are wrapped properly when maxLineLength is specified",
+        () {
+      var parser = new ArgParser(maxLineLength: 60);
+      parser.addFlag('long',
+          help: 'The flag with a really long help text that will be wrapped.');
+      parser.addFlag('longNewline',
+          help: 'The flag with a really long help text and newlines\n\nthat '
+              'will still be wrapped because it is really long.');
+      parser.addFlag('solid',
+          help:
+              'The-flag-with-no-whitespace-that-will-be-wrapped-by-splitting-a-word.');
+      parser.addFlag('small1', help: ' a ');
+      parser.addFlag('small2', help: ' a');
+      parser.addFlag('small3', help: 'a ');
+      validateUsage(parser, '''
+          --[no-]long           The flag with a really long help text
+                                that will be wrapped.
+
+          --[no-]longNewline    The flag with a really long help text
+                                and newlines
+                                
+                                that will still be wrapped because it
+                                is really long.
+
+          --[no-]solid          The-flag-with-no-whitespace-that-will-
+                                be-wrapped-by-splitting-a-word.
+
+          --[no-]small1         a
+          --[no-]small2         a
+          --[no-]small3         a
+          ''');
+    });
+
+    test(
+        "help strings are wrapped with at 10 chars when maxHelpLineLength is "
+        "smaller than available space", () {
+      var parser = new ArgParser(maxLineLength: 1);
+      parser.addFlag('long',
+          help: 'The flag with a really long help text that will be wrapped.');
+      parser.addFlag('longNewline',
+          help:
+              'The flag with a really long help text and newlines\n\nthat will '
+              'still be wrapped because it is really long.');
+      parser.addFlag('solid',
+          help:
+              'The-flag-with-no-whitespace-that-will-be-wrapped-by-splitting-a-word.');
+      parser.addFlag('small1', help: ' a ');
+      parser.addFlag('small2', help: ' a');
+      parser.addFlag('small3', help: 'a ');
+      validateUsage(parser, '''
+          --[no-]long           The flag
+                                with a
+                                really
+                                long help
+                                text that
+                                will be
+                                wrapped.
+          
+          --[no-]longNewline    The flag
+                                with a
+                                really
+                                long help
+                                text and
+                                newlines
+                                
+                                that will
+                                still be
+                                wrapped
+                                because it
+                                is really
+                                long.
+          
+          --[no-]solid          The-flag-w
+                                ith-no-whi
+                                tespace-th
+                                at-will-be
+                                -wrapped-b
+                                y-splittin
+                                g-a-word.
+          
+          --[no-]small1         a
+          --[no-]small2         a
+          --[no-]small3         a
+          ''');
+    });
+
     group("separators", () {
       test("separates options where it's placed", () {
         var parser = new ArgParser();

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -370,43 +370,65 @@ void main() {
       parser.addFlag('solid',
           help:
               'The-flag-with-no-whitespace-that-will-be-wrapped-by-splitting-a-word.');
+      parser.addFlag('longWhitespace',
+          help: '           The flag with a really long help text and whitespace at the start.');
+      parser.addFlag('longTrailspace',
+          help: 'The flag with a really long help text and whitespace at the end.             ');
       parser.addFlag('small1', help: ' a ');
       parser.addFlag('small2', help: ' a');
       parser.addFlag('small3', help: 'a ');
       validateUsage(parser, '''
-          --[no-]long           The flag
-                                with a
-                                really
-                                long help
-                                text that
-                                will be
-                                wrapped.
+          --[no-]long              The flag
+                                   with a
+                                   really
+                                   long help
+                                   text that
+                                   will be
+                                   wrapped.
           
-          --[no-]longNewline    The flag
-                                with a
-                                really
-                                long help
-                                text and
-                                newlines
-                                
-                                that will
-                                still be
-                                wrapped
-                                because it
-                                is really
-                                long.
+          --[no-]longNewline       The flag
+                                   with a
+                                   really
+                                   long help
+                                   text and
+                                   newlines
+                                   
+                                   that will
+                                   still be
+                                   wrapped
+                                   because it
+                                   is really
+                                   long.
           
-          --[no-]solid          The-flag-w
-                                ith-no-whi
-                                tespace-th
-                                at-will-be
-                                -wrapped-b
-                                y-splittin
-                                g-a-word.
+          --[no-]solid             The-flag-w
+                                   ith-no-whi
+                                   tespace-th
+                                   at-will-be
+                                   -wrapped-b
+                                   y-splittin
+                                   g-a-word.
           
-          --[no-]small1         a
-          --[no-]small2         a
-          --[no-]small3         a
+          --[no-]longWhitespace    The flag
+                                   with a
+                                   really
+                                   long help
+                                   text and
+                                   whitespace
+                                   at the
+                                   start.
+          
+          --[no-]longTrailspace    The flag
+                                   with a
+                                   really
+                                   long help
+                                   text and
+                                   whitespace
+                                   at the
+                                   end.
+          
+          --[no-]small1            a
+          --[no-]small2            a
+          --[no-]small3            a
           ''');
     });
 


### PR DESCRIPTION
This adds an _optional_ `maxLineLength` argument to the ArgParser that will automatically wrap help text at the given column on the terminal.

Fixes #41