### PR TITLE
Adds --all to the help command

### DIFF
--- a/example/test_runner.dart
+++ b/example/test_runner.dart
@@ -10,10 +10,31 @@ library example;
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 
-main() {
-  var parser = ArgParser();
+class FooCommand extends Command<void> {
+  FooCommand() {
+    argParser.addFlag('all',
+        abbr: 'a',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Fooicizes all frobinators.');
+  }
 
+  @override
+  String get name => 'foo';
+
+  @override
+  String get description => 'Fooicizes the frobinator';
+}
+
+main(List<String> args) {
+  var commandRunner =
+      CommandRunner<void>('test_runner', 'An Example of package:args usage');
+
+  commandRunner.addCommand(FooCommand());
+
+  var parser = commandRunner.argParser;
   parser.addSeparator('===== Platform');
 
   parser.addOption('compiler',
@@ -165,5 +186,5 @@ is 'dart file.dart' and you specify special command
   parser.addOption('drt', help: 'Path to content shell executable');
   parser.addOption('dartium', help: 'Path to Dartium Chrome executable');
 
-  print(parser.usage);
+  commandRunner.run(args);
 }

--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -2,12 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:io';
+
 import '../command_runner.dart';
+import 'utils.dart';
 
 /// The built-in help command that's added to every [CommandRunner].
 ///
 /// This command displays help information for the various subcommands.
 class HelpCommand<T> extends Command<T> {
+  HelpCommand() {
+    argParser.addFlag('all',
+        abbr: 'a',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Output help for every command and subcommand.');
+    argParser.addOption('output',
+        abbr: 'o',
+        help: 'When --split is given, the output directory. '
+            'When --split is not given, the output file.',
+        valueHelp: 'OUTPUT');
+    argParser.addFlag('split',
+        abbr: 's',
+        defaultsTo: false,
+        negatable: false,
+        help:
+            'Split help output by subcommand into files written to --output.');
+  }
+
   @override
   final name = "help";
 
@@ -19,7 +42,13 @@ class HelpCommand<T> extends Command<T> {
   String get invocation => "${runner.executableName} help [command]";
 
   @override
-  T run() {
+  Future<T> run() async {
+    // help --all prints all help text.
+    if (argResults['all']) {
+      await _outputAllHelp();
+      return null;
+    }
+
     // Show the default help if no command was specified.
     if (argResults.rest.isEmpty) {
       runner.printUsage();
@@ -54,5 +83,68 @@ class HelpCommand<T> extends Command<T> {
 
     command.printUsage();
     return null;
+  }
+
+  // Outputs all help text as designated by the flags --split and --output.
+  Future<void> _outputAllHelp() async {
+    final bool split = argResults['split'];
+    final String output = argResults['output'] ?? (split ? '.' : null);
+
+    if (split) {
+      Directory(output).createSync(recursive: true);
+    }
+
+    IOSink outSink;
+    try {
+      if (!split) {
+        outSink = output == null ? PrintIOSink() : File(output).openWrite();
+      }
+      for (List<String> helpText in _helpMessages) {
+        if (split) {
+          await outSink?.flush();
+          await outSink?.close();
+          final String helpFile =
+              '$output${Platform.pathSeparator}${helpText[0]}.txt';
+          outSink = File(helpFile).openWrite();
+        }
+        outSink.write(helpText[1]);
+      }
+    } finally {
+      if (outSink != stdout) {
+        await outSink?.flush();
+        await outSink?.close();
+      }
+    }
+  }
+
+  String _subcommandChain(Command command) {
+    List<String> parents = <String>[command.name];
+    for (Command c = command.parent; c != null; c = c.parent) {
+      parents.add(c.name);
+    }
+    return parents.reversed.join("_");
+  }
+
+  // Walks the subcommand tree, yielding all help text.
+  Iterable<List<String>> get _helpMessages sync* {
+    yield <String>[runner.executableName, '${runner.usage}\n'];
+    final Iterable<MapEntry<String, Command>> topLevelCommands =
+        runner.commands?.entries;
+    if (topLevelCommands == null) {
+      return;
+    }
+    final List<MapEntry<String, Command>> commandStack =
+        List<MapEntry<String, Command>>.from(topLevelCommands);
+    while (commandStack.isNotEmpty) {
+      final MapEntry<String, Command> command = commandStack.removeAt(0);
+      if (command.value.subcommands != null) {
+        commandStack.insertAll(0, command.value.subcommands.entries);
+      }
+      yield <String>[
+        _subcommandChain(command.value),
+        wrapText('Command: ${command.key}\n${command.value.usage}\n',
+            length: argParser.usageLineLength)
+      ];
+    }
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,10 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
 
 /// Pads [source] to [length] by adding spaces at the end.
@@ -138,4 +142,71 @@ List<String> wrapTextAsLines(String text, {int start = 0, int length}) {
     result.add(line.substring(currentLineStart).trim());
   }
   return result;
+}
+
+// When an IOSink that prints to the terminal is desired, normally [stdout] is
+// used. However, package:args's testing strategy is based on the zone override
+// for print() installed by package:test. Thus, we wrap calls to print() in an
+// IOSink implementation for use in this case.
+class PrintIOSink implements IOSink {
+  PrintIOSink();
+
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  void write(Object obj) => _buffer.write(obj);
+
+  @override
+  void writeAll(Iterable objects, [String separator = ""]) =>
+      _buffer.writeAll(objects, separator);
+
+  @override
+  void writeCharCode(int charCode) => _buffer.writeCharCode(charCode);
+
+  @override
+  void writeln([Object obj = ""]) => _buffer.writeln(obj);
+
+  @override
+  Future get done => null;
+
+  @override
+  Future close() async {
+    if (_buffer.isNotEmpty) {
+      print(_buffer);
+      _buffer.clear();
+    }
+  }
+
+  @override
+  Future flush() async {
+    if (_buffer.isNotEmpty) {
+      print(_buffer);
+      _buffer.clear();
+    }
+  }
+
+  @override
+  Encoding get encoding {
+    throw UnimplementedError('PrintIOSink ignores encoding');
+  }
+
+  @override
+  set encoding(Encoding e) {
+    throw UnimplementedError('PrintIOSink ignores encoding');
+  }
+
+  @override
+  void add(List<int> data) {
+    throw UnimplementedError('add() is not supported by this IOSink.');
+  }
+
+  @override
+  void addError(Object error, [StackTrace stackTrace]) {
+    throw UnimplementedError('addError() is not supported by this IOSink.');
+  }
+
+  @override
+  Future addStream(Stream<List<int>> stream) {
+    throw UnimplementedError('addStream() is not supported by this IOSink.');
+  }
 }

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -299,9 +299,48 @@ Run "test help" to see global options.
 Display help information for test.
 
 Usage: test help [command]
+-h, --help               Print this usage information.
+-a, --all                Output help for every command and subcommand.
+-o, --output=<OUTPUT>    When --split is given, the output directory. When --split is not given, the output file.
+-s, --split              Split help output by subcommand into files written to --output.
+
+Run "test help" to see global options.
+"""));
+      });
+
+      test("with --all, prints all help text", () {
+        runner.addCommand(FooCommand());
+        expect(() => runner.run(["help", "--all"]), prints("""
+A test command runner.
+
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+  foo    Set a value.
+  help   Display help information for test.
+
+Run "test help <command>" for more information about a command.
+Command: help
+Display help information for test.
+
+Usage: test help [command]
+-h, --help               Print this usage information.
+-a, --all                Output help for every command and subcommand.
+-o, --output=<OUTPUT>    When --split is given, the output directory. When --split is not given, the output file.
+-s, --split              Split help output by subcommand into files written to --output.
+
+Run "test help" to see global options.
+Command: foo
+Set a value.
+
+Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
 Run "test help" to see global options.
+
 """));
       });
     });


### PR DESCRIPTION
This PR adds flags to the omnipresent 'help' command to control output of all help text. It does this by adding an `--all` flag to the `help` command, and flags `--split` and `--output` that control where the output goes. The intention is that command line tools can e.g. auto-generate their documentation.