### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- 2.0.0
+- 2.3.0
 - dev
 
 dart_task:

--- a/example/test_runner.dart
+++ b/example/test_runner.dart
@@ -11,7 +11,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-main() {
+void main() {
   var parser = ArgParser();
 
   parser.addSeparator('===== Platform');

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -33,13 +33,13 @@ class CommandRunner<T> {
   ///
   /// Defaults to "$executableName <command> `arguments`". Subclasses can
   /// override this for a more specific template.
-  String get invocation => "$executableName <command> [arguments]";
+  String get invocation => '$executableName <command> [arguments]';
 
   /// Generates a string displaying usage information for the executable.
   ///
   /// This includes usage for the global arguments as well as a list of
   /// top-level commands.
-  String get usage => _wrap("$description\n\n") + _usageWithoutDescription;
+  String get usage => _wrap('$description\n\n') + _usageWithoutDescription;
 
   /// An optional footer for [usage].
   ///
@@ -49,7 +49,7 @@ class CommandRunner<T> {
 
   /// Returns [usage] with [description] removed from the beginning.
   String get _usageWithoutDescription {
-    var usagePrefix = "Usage:";
+    var usagePrefix = 'Usage:';
     var buffer = StringBuffer();
     buffer.writeln(
         '$usagePrefix ${_wrap(invocation, hangingIndent: usagePrefix.length)}\n');
@@ -96,7 +96,7 @@ class CommandRunner<T> {
 
   /// Adds [Command] as a top-level command to this runner.
   void addCommand(Command<T> command) {
-    var names = [command.name]..addAll(command.aliases);
+    var names = [command.name, ...command.aliases];
     for (var name in names) {
       _commands[name] = command;
       argParser.addCommand(name, command.argParser);
@@ -175,7 +175,7 @@ class CommandRunner<T> {
       command._globalResults = topLevelResults;
       command._argResults = argResults;
       commands = command._subcommands;
-      commandString += " ${argResults.name}";
+      commandString += ' ${argResults.name}';
 
       if (argResults['help']) {
         command.printUsage();
@@ -220,7 +220,7 @@ abstract class Command<T> {
   /// [CommandRunner.usage].
   ///
   /// This defaults to the first line of [description].
-  String get summary => description.split("\n").first;
+  String get summary => description.split('\n').first;
 
   /// A single-line template for how to invoke this command (e.g. `"pub get
   /// `package`"`).
@@ -231,10 +231,10 @@ abstract class Command<T> {
     }
     parents.add(runner.executableName);
 
-    var invocation = parents.reversed.join(" ");
+    var invocation = parents.reversed.join(' ');
     return _subcommands.isNotEmpty
-        ? "$invocation <subcommand> [arguments]"
-        : "$invocation [arguments]";
+        ? '$invocation <subcommand> [arguments]'
+        : '$invocation [arguments]';
   }
 
   /// The command's parent command, if this is a subcommand.
@@ -283,7 +283,7 @@ abstract class Command<T> {
   ///
   /// This includes usage for the command's arguments as well as a list of
   /// subcommands, if there are any.
-  String get usage => _wrap("$description\n\n") + _usageWithoutDescription;
+  String get usage => _wrap('$description\n\n') + _usageWithoutDescription;
 
   /// An optional footer for [usage].
   ///
@@ -299,7 +299,7 @@ abstract class Command<T> {
   /// Returns [usage] with [description] removed from the beginning.
   String get _usageWithoutDescription {
     var length = argParser.usageLineLength;
-    var usagePrefix = "Usage: ";
+    var usagePrefix = 'Usage: ';
     var buffer = StringBuffer()
       ..writeln(
           usagePrefix + _wrap(invocation, hangingIndent: usagePrefix.length))
@@ -373,12 +373,12 @@ abstract class Command<T> {
   /// The return value is wrapped in a `Future` if necessary and returned by
   /// [CommandRunner.runCommand].
   FutureOr<T> run() {
-    throw UnimplementedError(_wrap("Leaf command $this must implement run()."));
+    throw UnimplementedError(_wrap('Leaf command $this must implement run().'));
   }
 
   /// Adds [Command] as a subcommand of this.
   void addSubcommand(Command<T> command) {
-    var names = [command.name]..addAll(command.aliases);
+    var names = [command.name, ...command.aliases];
     for (var name in names) {
       _subcommands[name] = command;
       argParser.addCommand(name, command.argParser);

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -9,28 +9,36 @@ import 'parser.dart';
 
 /// An ArgParser that treats *all input* as non-option arguments.
 class AllowAnythingParser implements ArgParser {
+  @override
   Map<String, Option> get options => const {};
+  @override
   Map<String, ArgParser> get commands => const {};
+  @override
   bool get allowTrailingOptions => false;
+  @override
   bool get allowsAnything => true;
+  @override
   int get usageLineLength => null;
 
+  @override
   ArgParser addCommand(String name, [ArgParser parser]) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addCommands() isn't supported.");
   }
 
+  @override
   void addFlag(String name,
       {String abbr,
       String help,
       bool defaultsTo = false,
       bool negatable = true,
-      void callback(bool value),
+      void Function(bool) callback,
       bool hide = false}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addFlag() isn't supported.");
   }
 
+  @override
   void addOption(String name,
       {String abbr,
       String help,
@@ -46,6 +54,7 @@ class AllowAnythingParser implements ArgParser {
         "ArgParser.allowAnything().addOption() isn't supported.");
   }
 
+  @override
   void addMultiOption(String name,
       {String abbr,
       String help,
@@ -53,28 +62,34 @@ class AllowAnythingParser implements ArgParser {
       Iterable<String> allowed,
       Map<String, String> allowedHelp,
       Iterable<String> defaultsTo,
-      void callback(List<String> values),
+      void Function(List<String>) callback,
       bool splitCommas = true,
       bool hide = false}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addMultiOption() isn't supported.");
   }
 
+  @override
   void addSeparator(String text) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addSeparator() isn't supported.");
   }
 
+  @override
   ArgResults parse(Iterable<String> args) =>
       Parser(null, this, args.toList()).parse();
 
+  @override
   String getUsage() => usage;
 
-  String get usage => "";
+  @override
+  String get usage => '';
 
-  getDefault(String option) {
+  @override
+  dynamic getDefault(String option) {
     throw ArgumentError('No option named $option');
   }
 
+  @override
   Option findByAbbreviation(String abbr) => null;
 }

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -325,7 +325,7 @@ class ArgParser {
   /// Generates a string displaying usage information for the defined options.
   ///
   /// This is basically the help text shown on the command line.
-  @Deprecated("Replaced with get usage. getUsage() will be removed in args 1.0")
+  @Deprecated('Replaced with get usage. getUsage() will be removed in args 1.0')
   String getUsage() => usage;
 
   /// Generates a string displaying usage information for the defined options.

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -71,12 +71,11 @@ class ArgParser {
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
       {bool allowTrailingOptions = true, this.usageLineLength})
-      : this._options = options,
-        this.options = UnmodifiableMapView(options),
-        this._commands = commands,
-        this.commands = UnmodifiableMapView(commands),
-        this.allowTrailingOptions =
-            allowTrailingOptions != null ? allowTrailingOptions : false;
+      : _options = options,
+        options = UnmodifiableMapView(options),
+        _commands = commands,
+        commands = UnmodifiableMapView(commands),
+        allowTrailingOptions = allowTrailingOptions ?? false;
 
   /// Defines a command.
   ///
@@ -89,7 +88,7 @@ class ArgParser {
       throw ArgumentError('Duplicate command "$name".');
     }
 
-    if (parser == null) parser = ArgParser();
+    parser ??= ArgParser();
     _commands[name] = parser;
     return parser;
   }
@@ -127,7 +126,7 @@ class ArgParser {
       String help,
       bool defaultsTo = false,
       bool negatable = true,
-      void callback(bool value),
+      void Function(bool) callback,
       bool hide = false}) {
     _addOption(
         name,
@@ -191,8 +190,8 @@ class ArgParser {
       Map<String, String> allowedHelp,
       String defaultsTo,
       Function callback,
-      @Deprecated("Use addMultiOption() instead.") bool allowMultiple = false,
-      @Deprecated("Use addMultiOption() instead.") bool splitCommas,
+      @Deprecated('Use addMultiOption() instead.') bool allowMultiple = false,
+      @Deprecated('Use addMultiOption() instead.') bool splitCommas,
       bool hide = false}) {
     if (!allowMultiple && splitCommas != null) {
       throw ArgumentError(
@@ -259,7 +258,7 @@ class ArgParser {
       Iterable<String> allowed,
       Map<String, String> allowedHelp,
       Iterable<String> defaultsTo,
-      void callback(List<String> values),
+      void Function(List<String>) callback,
       bool splitCommas = true,
       bool hide = false}) {
     _addOption(
@@ -338,7 +337,7 @@ class ArgParser {
 
   /// Get the default value for an option. Useful after parsing to test if the
   /// user specified something other than the default.
-  getDefault(String option) {
+  dynamic getDefault(String option) {
     if (!options.containsKey(option)) {
       throw ArgumentError('No option named $option');
     }

--- a/lib/src/arg_results.dart
+++ b/lib/src/arg_results.dart
@@ -55,11 +55,11 @@ class ArgResults {
   /// Creates a new [ArgResults].
   ArgResults._(this._parser, this._parsed, this.name, this.command,
       List<String> rest, List<String> arguments)
-      : this.rest = UnmodifiableListView(rest),
-        this.arguments = UnmodifiableListView(arguments);
+      : rest = UnmodifiableListView(rest),
+        arguments = UnmodifiableListView(arguments);
 
   /// Gets the parsed command-line option named [name].
-  operator [](String name) {
+  dynamic operator [](String name) {
     if (!_parser.options.containsKey(name)) {
       throw ArgumentError('Could not find an option named "$name".');
     }

--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -9,14 +9,14 @@ import '../command_runner.dart';
 /// This command displays help information for the various subcommands.
 class HelpCommand<T> extends Command<T> {
   @override
-  final name = "help";
+  final name = 'help';
 
   @override
   String get description =>
-      "Display help information for ${runner.executableName}.";
+      'Display help information for ${runner.executableName}.';
 
   @override
-  String get invocation => "${runner.executableName} help [command]";
+  String get invocation => '${runner.executableName} help [command]';
 
   @override
   T run() {
@@ -49,7 +49,7 @@ class HelpCommand<T> extends Command<T> {
 
       command = commands[name];
       commands = command.subcommands;
-      commandString += " $name";
+      commandString += ' $name';
     }
 
     command.printUsage();

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -37,7 +37,7 @@ class Option {
   /// `-avalue`.
   final String abbr;
 
-  @Deprecated("Use abbr instead.")
+  @Deprecated('Use abbr instead.')
   String get abbreviation => abbr;
 
   /// A description of this option.
@@ -53,10 +53,10 @@ class Option {
   final Map<String, String> allowedHelp;
 
   /// The value this option will have if the user doesn't explicitly pass it in
-  final defaultsTo;
+  final dynamic defaultsTo;
 
-  @Deprecated("Use defaultsTo instead.")
-  get defaultValue => defaultsTo;
+  @Deprecated('Use defaultsTo instead.')
+  dynamic get defaultValue => defaultsTo;
 
   /// Whether this flag's value can be set to `false`.
   ///
@@ -101,14 +101,13 @@ class Option {
       {this.negatable,
       bool splitCommas,
       this.hide = false})
-      : this.allowed = allowed == null ? null : List.unmodifiable(allowed),
-        this.allowedHelp =
+      : allowed = allowed == null ? null : List.unmodifiable(allowed),
+        allowedHelp =
             allowedHelp == null ? null : Map.unmodifiable(allowedHelp),
-        this.type = type,
+        type = type,
         // If the user doesn't specify [splitCommas], it defaults to true for
         // multiple options.
-        this.splitCommas =
-            splitCommas == null ? type == OptionType.multiple : splitCommas {
+        splitCommas = splitCommas ?? type == OptionType.multiple {
     if (name.isEmpty) {
       throw ArgumentError('Name cannot be empty.');
     } else if (name.startsWith('-')) {
@@ -153,9 +152,9 @@ class OptionType {
   /// An option that can only be `true` or `false`.
   ///
   /// The presence of the option name itself in the argument list means `true`.
-  static const flag = OptionType._("OptionType.flag");
+  static const flag = OptionType._('OptionType.flag');
 
-  @Deprecated("Use OptionType.flag instead.")
+  @Deprecated('Use OptionType.flag instead.')
   static const FLAG = flag; // ignore: constant_identifier_names
 
   /// An option that takes a single value.
@@ -167,9 +166,9 @@ class OptionType {
   ///     --mode=debug
   ///
   /// If the option is passed more than once, the last one wins.
-  static const single = OptionType._("OptionType.single");
+  static const single = OptionType._('OptionType.single');
 
-  @Deprecated("Use OptionType.single instead.")
+  @Deprecated('Use OptionType.single instead.')
   static const SINGLE = single; // ignore: constant_identifier_names
 
   /// An option that allows multiple values.
@@ -180,9 +179,9 @@ class OptionType {
   ///
   /// In the parsed `ArgResults`, a multiple-valued option will always return
   /// a list, even if one or no values were passed.
-  static const multiple = OptionType._("OptionType.multiple");
+  static const multiple = OptionType._('OptionType.multiple');
 
-  @Deprecated("Use OptionType.multiple instead.")
+  @Deprecated('Use OptionType.multiple instead.')
   static const MULTIPLE = multiple; // ignore: constant_identifier_names
 
   final String name;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -275,7 +275,7 @@ class Parser {
     var list = results.putIfAbsent(option.name, () => <String>[]);
 
     if (option.splitCommas) {
-      for (var element in value.split(",")) {
+      for (var element in value.split(',')) {
         _validateAllowed(option, element);
         list.add(element);
       }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -75,7 +75,7 @@ class Parser {
         } on ArgParserException catch (error) {
           if (commandName == null) rethrow;
           throw ArgParserException(
-              error.message, [commandName]..addAll(error.commands));
+              error.message, [commandName, ...error.commands]);
         }
 
         // All remaining arguments were passed to command so clear them here.

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -70,7 +70,7 @@ class Usage {
     for (var optionOrSeparator in optionsAndSeparators) {
       if (optionOrSeparator is String) {
         // Ensure that there's always a blank line before a separator.
-        if (buffer.isNotEmpty) buffer.write("\n\n");
+        if (buffer.isNotEmpty) buffer.write('\n\n');
         buffer.write(optionOrSeparator);
         newlinesNeeded = 1;
         continue;
@@ -134,7 +134,7 @@ class Usage {
       result = '--${option.name}';
     }
 
-    if (option.valueHelp != null) result += "=<${option.valueHelp}>";
+    if (option.valueHelp != null) result += '=<${option.valueHelp}>';
 
     return result;
   }

--- a/lib/src/usage_exception.dart
+++ b/lib/src/usage_exception.dart
@@ -9,5 +9,5 @@ class UsageException implements Exception {
   UsageException(this.message, this.usage);
 
   @override
-  String toString() => "$message\n\n$usage";
+  String toString() => '$message\n\n$usage';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: args
-version: 1.5.2
-author: "Dart Team <misc@dartlang.org>"
+version: 1.5.3-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.4.0

--- a/test/allow_anything_test.dart
+++ b/test/allow_anything_test.dart
@@ -19,14 +19,14 @@ void main() {
       expect(parser.allowsAnything, isTrue);
       expect(parser.usage, isEmpty);
       expect(parser.getUsage(), isEmpty); // ignore: deprecated_member_use
-      expect(parser.findByAbbreviation("a"), isNull);
+      expect(parser.findByAbbreviation('a'), isNull);
     });
 
     test('mutation methods throw errors', () {
-      expect(() => parser.addCommand("command"), throwsUnsupportedError);
-      expect(() => parser.addFlag("flag"), throwsUnsupportedError);
-      expect(() => parser.addOption("option"), throwsUnsupportedError);
-      expect(() => parser.addSeparator("==="), throwsUnsupportedError);
+      expect(() => parser.addCommand('command'), throwsUnsupportedError);
+      expect(() => parser.addFlag('flag'), throwsUnsupportedError);
+      expect(() => parser.addOption('option'), throwsUnsupportedError);
+      expect(() => parser.addSeparator('==='), throwsUnsupportedError);
     });
 
     test('getDefault() throws an error', () {

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 import 'test_utils.dart';
 
-const _defaultUsage = """
+const _defaultUsage = '''
 Usage: test <command> [arguments]
 
 Global options:
@@ -16,30 +16,30 @@ Global options:
 Available commands:
   help   Display help information for test.
 
-Run "test help <command>" for more information about a command.""";
+Run "test help <command>" for more information about a command.''';
 
 void main() {
   var runner;
   setUp(() {
-    runner = CommandRunner("test", "A test command runner.");
+    runner = CommandRunner('test', 'A test command runner.');
   });
 
-  test(".invocation has a sane default", () {
-    expect(runner.invocation, equals("test <command> [arguments]"));
+  test('.invocation has a sane default', () {
+    expect(runner.invocation, equals('test <command> [arguments]'));
   });
 
-  group(".usage", () {
-    test("returns the usage string", () {
-      expect(runner.usage, equals("""
+  group('.usage', () {
+    test('returns the usage string', () {
+      expect(runner.usage, equals('''
 A test command runner.
 
-$_defaultUsage"""));
+$_defaultUsage'''));
     });
 
-    test("contains custom commands", () {
+    test('contains custom commands', () {
       runner.addCommand(FooCommand());
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -51,13 +51,13 @@ Available commands:
   foo    Set a value.
   help   Display help information for test.
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
-    test("truncates newlines in command descriptions by default", () {
+    test('truncates newlines in command descriptions by default', () {
       runner.addCommand(MultilineCommand());
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -69,13 +69,13 @@ Available commands:
   help        Display help information for test.
   multiline   Multi
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
-    test("supports newlines in command summaries", () {
+    test('supports newlines in command summaries', () {
       runner.addCommand(MultilineSummaryCommand());
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -88,13 +88,13 @@ Available commands:
   multiline   Multi
               line.
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
-    test("contains custom options", () {
-      runner.argParser.addFlag("foo", help: "Do something.");
+    test('contains custom options', () {
+      runner.argParser.addFlag('foo', help: 'Do something.');
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -106,22 +106,22 @@ Global options:
 Available commands:
   help   Display help information for test.
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
       runner.addCommand(HiddenCommand());
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
-$_defaultUsage"""));
+$_defaultUsage'''));
     });
 
     test("doesn't print aliases", () {
       runner.addCommand(AliasedCommand());
 
-      expect(runner.usage, equals("""
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -133,12 +133,12 @@ Available commands:
   aliased   Set a value.
   help      Display help information for test.
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
-    test("respects usageLineLength", () {
-      runner = CommandRunner("name", "desc", usageLineLength: 35);
-      expect(runner.usage, equals("""
+    test('respects usageLineLength', () {
+      runner = CommandRunner('name', 'desc', usageLineLength: 35);
+      expect(runner.usage, equals('''
 desc
 
 Usage: name <command> [arguments]
@@ -152,210 +152,210 @@ Available commands:
          for name.
 
 Run "name help <command>" for more
-information about a command."""));
+information about a command.'''));
     });
   });
 
-  test("usageException splits up the message and usage", () {
-    expect(() => runner.usageException("message"),
-        throwsUsageException("message", _defaultUsage));
+  test('usageException splits up the message and usage', () {
+    expect(() => runner.usageException('message'),
+        throwsUsageException('message', _defaultUsage));
   });
 
-  group("run()", () {
-    test("runs a command", () {
+  group('run()', () {
+    test('runs a command', () {
       var command = FooCommand();
       runner.addCommand(command);
 
       expect(
-          runner.run(["foo"]).then((_) {
+          runner.run(['foo']).then((_) {
             expect(command.hasRun, isTrue);
           }),
           completes);
     });
 
-    test("runs an asynchronous command", () {
+    test('runs an asynchronous command', () {
       var command = AsyncCommand();
       runner.addCommand(command);
 
       expect(
-          runner.run(["async"]).then((_) {
+          runner.run(['async']).then((_) {
             expect(command.hasRun, isTrue);
           }),
           completes);
     });
 
-    test("runs a command with a return value", () {
-      var runner = CommandRunner<int>("test", "");
+    test('runs a command with a return value', () {
+      var runner = CommandRunner<int>('test', '');
       var command = ValueCommand();
       runner.addCommand(command);
 
-      expect(runner.run(["foo"]), completion(equals(12)));
+      expect(runner.run(['foo']), completion(equals(12)));
     });
 
-    test("runs a command with an asynchronous return value", () {
-      var runner = CommandRunner<String>("test", "");
+    test('runs a command with an asynchronous return value', () {
+      var runner = CommandRunner<String>('test', '');
       var command = AsyncValueCommand();
       runner.addCommand(command);
 
-      expect(runner.run(["foo"]), completion(equals("hi")));
+      expect(runner.run(['foo']), completion(equals('hi')));
     });
 
-    test("runs a hidden comand", () {
+    test('runs a hidden comand', () {
       var command = HiddenCommand();
       runner.addCommand(command);
 
       expect(
-          runner.run(["hidden"]).then((_) {
+          runner.run(['hidden']).then((_) {
             expect(command.hasRun, isTrue);
           }),
           completes);
     });
 
-    test("runs an aliased comand", () {
+    test('runs an aliased comand', () {
       var command = AliasedCommand();
       runner.addCommand(command);
 
       expect(
-          runner.run(["als"]).then((_) {
+          runner.run(['als']).then((_) {
             expect(command.hasRun, isTrue);
           }),
           completes);
     });
 
-    test("runs a subcommand", () {
+    test('runs a subcommand', () {
       var command = AsyncCommand();
       runner.addCommand(FooCommand()..addSubcommand(command));
 
       expect(
-          runner.run(["foo", "async"]).then((_) {
+          runner.run(['foo', 'async']).then((_) {
             expect(command.hasRun, isTrue);
           }),
           completes);
     });
 
-    group("with --help", () {
-      test("with no command prints the usage", () {
-        expect(() => runner.run(["--help"]), prints("""
+    group('with --help', () {
+      test('with no command prints the usage', () {
+        expect(() => runner.run(['--help']), prints('''
 A test command runner.
 
 $_defaultUsage
-"""));
+'''));
       });
 
-      test("with a preceding command prints the usage for that command", () {
+      test('with a preceding command prints the usage for that command', () {
         var command = FooCommand();
         runner.addCommand(command);
 
-        expect(() => runner.run(["foo", "--help"]), prints("""
+        expect(() => runner.run(['foo', '--help']), prints('''
 Set a value.
 
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
 Run "test help" to see global options.
-"""));
+'''));
       });
 
-      test("with a following command prints the usage for that command", () {
+      test('with a following command prints the usage for that command', () {
         var command = FooCommand();
         runner.addCommand(command);
 
-        expect(() => runner.run(["--help", "foo"]), prints("""
+        expect(() => runner.run(['--help', 'foo']), prints('''
 Set a value.
 
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
 Run "test help" to see global options.
-"""));
+'''));
       });
     });
 
-    group("with help command", () {
-      test("with no command prints the usage", () {
-        expect(() => runner.run(["help"]), prints("""
+    group('with help command', () {
+      test('with no command prints the usage', () {
+        expect(() => runner.run(['help']), prints('''
 A test command runner.
 
 $_defaultUsage
-"""));
+'''));
       });
 
-      test("with a command prints the usage for that command", () {
+      test('with a command prints the usage for that command', () {
         var command = FooCommand();
         runner.addCommand(command);
 
-        expect(() => runner.run(["help", "foo"]), prints("""
+        expect(() => runner.run(['help', 'foo']), prints('''
 Set a value.
 
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
 Run "test help" to see global options.
-"""));
+'''));
       });
 
-      test("prints its own usage", () {
-        expect(() => runner.run(["help", "help"]), prints("""
+      test('prints its own usage', () {
+        expect(() => runner.run(['help', 'help']), prints('''
 Display help information for test.
 
 Usage: test help [command]
 -h, --help    Print this usage information.
 
 Run "test help" to see global options.
-"""));
+'''));
       });
     });
 
-    group("with an invalid argument", () {
-      test("at the root throws the root usage", () {
+    group('with an invalid argument', () {
+      test('at the root throws the root usage', () {
         expect(
-            runner.run(["--asdf"]),
+            runner.run(['--asdf']),
             throwsUsageException(
                 'Could not find an option named "asdf".', '$_defaultUsage'));
       });
 
-      test("for a command throws the command usage", () {
+      test('for a command throws the command usage', () {
         var command = FooCommand();
         runner.addCommand(command);
 
-        expect(runner.run(["foo", "--asdf"]),
-            throwsUsageException('Could not find an option named "asdf".', """
+        expect(runner.run(['foo', '--asdf']),
+            throwsUsageException('Could not find an option named "asdf".', '''
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
       });
     });
   });
 
-  group("with a footer", () {
+  group('with a footer', () {
     setUp(() {
-      runner = CommandRunnerWithFooter("test", "A test command runner.");
+      runner = CommandRunnerWithFooter('test', 'A test command runner.');
     });
 
-    test("includes the footer in the usage string", () {
-      expect(runner.usage, equals("""
+    test('includes the footer in the usage string', () {
+      expect(runner.usage, equals('''
 A test command runner.
 
 $_defaultUsage
-Also, footer!"""));
+Also, footer!'''));
     });
 
-    test("includes the footer in usage errors", () {
+    test('includes the footer in usage errors', () {
       expect(
-          runner.run(["--bad"]),
+          runner.run(['--bad']),
           throwsUsageException('Could not find an option named "bad".',
-              "$_defaultUsage\nAlso, footer!"));
+              '$_defaultUsage\nAlso, footer!'));
     });
   });
 
-  group("with a footer and wrapping", () {
+  group('with a footer and wrapping', () {
     setUp(() {
       runner =
-          CommandRunnerWithFooterAndWrapping("test", "A test command runner.");
+          CommandRunnerWithFooterAndWrapping('test', 'A test command runner.');
     });
-    test("includes the footer in the usage string", () {
-      expect(runner.usage, equals("""
+    test('includes the footer in the usage string', () {
+      expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -375,12 +375,12 @@ we can check wrapping on long footer
 messages.
 
 And make sure that they preserve
-newlines properly."""));
+newlines properly.'''));
     });
 
-    test("includes the footer in usage errors", () {
-      expect(runner.run(["--bad"]),
-          throwsUsageException('Could not find an option named "bad".', """
+    test('includes the footer in usage errors', () {
+      expect(runner.run(['--bad']),
+          throwsUsageException('Could not find an option named "bad".', '''
 Usage: test <command> [arguments]
 
 Global options:
@@ -398,21 +398,21 @@ we can check wrapping on long footer
 messages.
 
 And make sure that they preserve
-newlines properly."""));
+newlines properly.'''));
     });
   });
 
-  group("throws a useful error when", () {
-    test("arg parsing fails", () {
+  group('throws a useful error when', () {
+    test('arg parsing fails', () {
       expect(
-          runner.run(["--bad"]),
+          runner.run(['--bad']),
           throwsUsageException(
               'Could not find an option named "bad".', _defaultUsage));
     });
 
     test("a top-level command doesn't exist", () {
       expect(
-          runner.run(["bad"]),
+          runner.run(['bad']),
           throwsUsageException(
               'Could not find a command named "bad".', _defaultUsage));
     });
@@ -420,8 +420,8 @@ newlines properly."""));
     test("a subcommand doesn't exist", () {
       runner.addCommand(FooCommand()..addSubcommand(AsyncCommand()));
 
-      expect(runner.run(["foo bad"]),
-          throwsUsageException('Could not find a command named "foo bad".', """
+      expect(runner.run(['foo bad']),
+          throwsUsageException('Could not find a command named "foo bad".', '''
 Usage: test <command> [arguments]
 
 Global options:
@@ -431,32 +431,32 @@ Available commands:
   foo    Set a value.
   help   Display help information for test.
 
-Run "test help <command>" for more information about a command."""));
+Run "test help <command>" for more information about a command.'''));
     });
 
     test("a subcommand wasn't passed", () {
       runner.addCommand(FooCommand()..addSubcommand(AsyncCommand()));
 
-      expect(runner.run(["foo"]),
-          throwsUsageException('Missing subcommand for "test foo".', """
+      expect(runner.run(['foo']),
+          throwsUsageException('Missing subcommand for "test foo".', '''
 Usage: test foo <subcommand> [arguments]
 -h, --help    Print this usage information.
 
 Available subcommands:
   async   Set a value asynchronously.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
 
     test("a command that doesn't take arguments was given them", () {
       runner.addCommand(FooCommand());
 
-      expect(runner.run(["foo", "bar"]),
-          throwsUsageException('Command "foo" does not take any arguments.', """
+      expect(runner.run(['foo', 'bar']),
+          throwsUsageException('Command "foo" does not take any arguments.', '''
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
   });
 }

--- a/test/command_test.dart
+++ b/test/command_test.dart
@@ -12,56 +12,56 @@ void main() {
     foo = FooCommand();
 
     // Make sure [Command.runner] is set up.
-    CommandRunner("test", "A test command runner.").addCommand(foo);
+    CommandRunner('test', 'A test command runner.').addCommand(foo);
   });
 
-  group(".invocation has a sane default", () {
-    test("without subcommands", () {
-      expect(foo.invocation, equals("test foo [arguments]"));
+  group('.invocation has a sane default', () {
+    test('without subcommands', () {
+      expect(foo.invocation, equals('test foo [arguments]'));
     });
 
-    test("with subcommands", () {
+    test('with subcommands', () {
       foo.addSubcommand(AsyncCommand());
-      expect(foo.invocation, equals("test foo <subcommand> [arguments]"));
+      expect(foo.invocation, equals('test foo <subcommand> [arguments]'));
     });
 
-    test("for a subcommand", () {
+    test('for a subcommand', () {
       var async = AsyncCommand();
       foo.addSubcommand(async);
 
-      expect(async.invocation, equals("test foo async [arguments]"));
+      expect(async.invocation, equals('test foo async [arguments]'));
     });
   });
 
-  group(".usage", () {
-    test("returns the usage string", () {
-      expect(foo.usage, equals("""
+  group('.usage', () {
+    test('returns the usage string', () {
+      expect(foo.usage, equals('''
 Set a value.
 
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
 
-    test("contains custom options", () {
-      foo.argParser.addFlag("flag", help: "Do something.");
+    test('contains custom options', () {
+      foo.argParser.addFlag('flag', help: 'Do something.');
 
-      expect(foo.usage, equals("""
+      expect(foo.usage, equals('''
 Set a value.
 
 Usage: test foo [arguments]
 -h, --help         Print this usage information.
     --[no-]flag    Do something.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
 
     test("doesn't print hidden subcommands", () {
       foo.addSubcommand(AsyncCommand());
       foo.addSubcommand(HiddenCommand());
 
-      expect(foo.usage, equals("""
+      expect(foo.usage, equals('''
 Set a value.
 
 Usage: test foo <subcommand> [arguments]
@@ -70,13 +70,13 @@ Usage: test foo <subcommand> [arguments]
 Available subcommands:
   async   Set a value asynchronously.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
 
     test("doesn't print subcommand aliases", () {
       foo.addSubcommand(AliasedCommand());
 
-      expect(foo.usage, equals("""
+      expect(foo.usage, equals('''
 Set a value.
 
 Usage: test foo <subcommand> [arguments]
@@ -85,18 +85,18 @@ Usage: test foo <subcommand> [arguments]
 Available subcommands:
   aliased   Set a value.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
     });
 
-    test("wraps long command descriptions with subcommands", () {
+    test('wraps long command descriptions with subcommands', () {
       var wrapping = WrappingCommand();
 
       // Make sure [Command.runner] is set up.
-      CommandRunner("longtest", "A long-lined test command runner.")
+      CommandRunner('longtest', 'A long-lined test command runner.')
           .addCommand(wrapping);
 
       wrapping.addSubcommand(LongCommand());
-      expect(wrapping.usage, equals("""
+      expect(wrapping.usage, equals('''
 This command overrides the argParser so
 that it will wrap long lines.
 
@@ -111,17 +111,17 @@ Available subcommands:
          wrapped sometimes.
 
 Run "longtest help" to see global
-options."""));
+options.'''));
     });
 
-    test("wraps long command descriptions", () {
+    test('wraps long command descriptions', () {
       var longCommand = LongCommand();
 
       // Make sure [Command.runner] is set up.
-      CommandRunner("longtest", "A long-lined test command runner.")
+      CommandRunner('longtest', 'A long-lined test command runner.')
           .addCommand(longCommand);
 
-      expect(longCommand.usage, equals("""
+      expect(longCommand.usage, equals('''
 This command has a long description that
 needs to be wrapped sometimes.
 It has embedded newlines,
@@ -137,20 +137,20 @@ Usage: longtest long [arguments]
               information.
 
 Run "longtest help" to see global
-options."""));
+options.'''));
     });
   });
 
-  test("usageException splits up the message and usage", () {
+  test('usageException splits up the message and usage', () {
     expect(
-        () => foo.usageException("message"), throwsUsageException("message", """
+        () => foo.usageException('message'), throwsUsageException('message', '''
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
-Run "test help" to see global options."""));
+Run "test help" to see global options.'''));
   });
 
-  test("considers a command hidden if all its subcommands are hidden", () {
+  test('considers a command hidden if all its subcommands are hidden', () {
     foo.addSubcommand(HiddenCommand());
     expect(foo.hidden, isTrue);
   });

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -153,7 +153,7 @@ void main() {
         expect(a, isNull);
       });
 
-      group("with allowMultiple", () {
+      group('with allowMultiple', () {
         test('for multiple present, options are invoked with value as a list',
             () {
           var a;
@@ -255,7 +255,7 @@ void main() {
         });
       });
 
-      group("with addMultiOption", () {
+      group('with addMultiOption', () {
         test('for multiple present, options are invoked with value as a list',
             () {
           var a;
@@ -429,7 +429,7 @@ void main() {
       });
 
       group('throw if a comma-separated value is not allowed', () {
-        test("with allowMultiple", () {
+        test('with allowMultiple', () {
           var parser = ArgParser();
           parser.addOption(
             'mode',
@@ -440,7 +440,7 @@ void main() {
           throwsFormat(parser, ['-mdebug,profile']);
         });
 
-        test("with addMultiOption", () {
+        test('with addMultiOption', () {
           var parser = ArgParser();
           parser
               .addMultiOption('mode', abbr: 'm', allowed: ['debug', 'release']);

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 class CommandRunnerWithFooter extends CommandRunner {
   @override
-  String get usageFooter => "Also, footer!";
+  String get usageFooter => 'Also, footer!';
 
   CommandRunnerWithFooter(String executableName, String description)
       : super(executableName, description);
@@ -18,9 +18,10 @@ class CommandRunnerWithFooter extends CommandRunner {
 
 class CommandRunnerWithFooterAndWrapping extends CommandRunner {
   @override
-  String get usageFooter => "LONG footer! "
-      "This is a long footer, so we can check wrapping on long footer messages.\n\n"
-      "And make sure that they preserve newlines properly.";
+  String get usageFooter => 'LONG footer! '
+      'This is a long footer, so we can check wrapping on long footer messages.'
+      '\n\n'
+      'And make sure that they preserve newlines properly.';
 
   @override
   ArgParser get argParser => _argParser;
@@ -34,10 +35,10 @@ class FooCommand extends Command {
   var hasRun = false;
 
   @override
-  final name = "foo";
+  final name = 'foo';
 
   @override
-  final description = "Set a value.";
+  final description = 'Set a value.';
 
   @override
   final takesArguments = false;
@@ -50,10 +51,10 @@ class FooCommand extends Command {
 
 class ValueCommand extends Command<int> {
   @override
-  final name = "foo";
+  final name = 'foo';
 
   @override
-  final description = "Return a value.";
+  final description = 'Return a value.';
 
   @override
   final takesArguments = false;
@@ -64,26 +65,26 @@ class ValueCommand extends Command<int> {
 
 class AsyncValueCommand extends Command<String> {
   @override
-  final name = "foo";
+  final name = 'foo';
 
   @override
-  final description = "Return a future.";
+  final description = 'Return a future.';
 
   @override
   final takesArguments = false;
 
   @override
-  Future<String> run() async => "hi";
+  Future<String> run() async => 'hi';
 }
 
 class MultilineCommand extends Command {
   var hasRun = false;
 
   @override
-  final name = "multiline";
+  final name = 'multiline';
 
   @override
-  final description = "Multi\nline.";
+  final description = 'Multi\nline.';
 
   @override
   final takesArguments = false;
@@ -102,11 +103,11 @@ class WrappingCommand extends Command {
   final _argParser = ArgParser(usageLineLength: 40);
 
   @override
-  final name = "wrapping";
+  final name = 'wrapping';
 
   @override
   final description =
-      "This command overrides the argParser so that it will wrap long lines.";
+      'This command overrides the argParser so that it will wrap long lines.';
 
   @override
   final takesArguments = false;
@@ -125,14 +126,14 @@ class LongCommand extends Command {
   final _argParser = ArgParser(usageLineLength: 40);
 
   @override
-  final name = "long";
+  final name = 'long';
 
   @override
-  final description = "This command has a long description that needs to be "
-          "wrapped sometimes.\nIt has embedded newlines,\n"
-          "     and indented lines that also need to be wrapped and have their "
-          "indentation preserved.\n" +
-      ("0123456789" * 10);
+  final description = 'This command has a long description that needs to be '
+          'wrapped sometimes.\nIt has embedded newlines,\n'
+          '     and indented lines that also need to be wrapped and have their '
+          'indentation preserved.\n' +
+      ('0123456789' * 10);
 
   @override
   final takesArguments = false;
@@ -152,10 +153,10 @@ class HiddenCommand extends Command {
   var hasRun = false;
 
   @override
-  final name = "hidden";
+  final name = 'hidden';
 
   @override
-  final description = "Set a value.";
+  final description = 'Set a value.';
 
   @override
   final hidden = true;
@@ -173,16 +174,16 @@ class AliasedCommand extends Command {
   var hasRun = false;
 
   @override
-  final name = "aliased";
+  final name = 'aliased';
 
   @override
-  final description = "Set a value.";
+  final description = 'Set a value.';
 
   @override
   final takesArguments = false;
 
   @override
-  final aliases = const ["alias", "als"];
+  final aliases = const ['alias', 'als'];
 
   @override
   void run() {
@@ -194,10 +195,10 @@ class AsyncCommand extends Command {
   var hasRun = false;
 
   @override
-  final name = "async";
+  final name = 'async';
 
   @override
-  final description = "Set a value asynchronously.";
+  final description = 'Set a value asynchronously.';
 
   @override
   final takesArguments = false;

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     void expectThrows(List<String> args) {
       expect(() => parser.parse(args), throwsFormatException,
-          reason: "with allowTrailingOptions: true");
+          reason: 'with allowTrailingOptions: true');
     }
 
     test('collects non-options in rest', () {

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -321,7 +321,7 @@ void main() {
           ''');
     });
 
-    test("help strings are not wrapped if usageLineLength is null", () {
+    test('help strings are not wrapped if usageLineLength is null', () {
       var parser = ArgParser(usageLineLength: null);
       parser.addFlag('long',
           help: 'The flag with a really long help text that will not '
@@ -331,7 +331,7 @@ void main() {
           ''');
     });
 
-    test("help strings are wrapped properly when usageLineLength is specified",
+    test('help strings are wrapped properly when usageLineLength is specified',
         () {
       var parser = ArgParser(usageLineLength: 60);
       parser.addFlag('long',
@@ -377,8 +377,8 @@ void main() {
     });
 
     test(
-        "help strings are wrapped with at 10 chars when usageLineLength is "
-        "smaller than available space", () {
+        'help strings are wrapped with at 10 chars when usageLineLength is '
+        'smaller than available space', () {
       var parser = ArgParser(usageLineLength: 1);
       parser.addFlag('long',
           help: 'The flag with a really long help text that will be wrapped.');
@@ -429,7 +429,7 @@ void main() {
           ''');
     });
 
-    group("separators", () {
+    group('separators', () {
       test("separates options where it's placed", () {
         var parser = ArgParser();
         parser.addFlag('zebra', help: 'First');
@@ -487,7 +487,7 @@ void main() {
             ''');
       });
 
-      test("adds a newline after another separator", () {
+      test('adds a newline after another separator', () {
         var parser = ArgParser();
         parser.addSeparator('First');
         parser.addSeparator('Second');

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -6,43 +6,43 @@ import 'package:args/src/utils.dart';
 import 'package:test/test.dart';
 
 const _lineLength = 40;
-const _longLine = "This is a long line that needs to be wrapped.";
-final _longLineWithNewlines = "This is a long line with newlines that\n"
-        "needs to be wrapped.\n\n" +
-    "0123456789" * 5;
+const _longLine = 'This is a long line that needs to be wrapped.';
+final _longLineWithNewlines = 'This is a long line with newlines that\n'
+        'needs to be wrapped.\n\n' +
+    '0123456789' * 5;
 final _indentedLongLineWithNewlines =
-    "    This is an indented long line with newlines that\n"
-            "needs to be wrapped.\n\tAnd preserves tabs.\n      \n  " +
-        "0123456789" * 5;
-const _shortLine = "Short line.";
-const _indentedLongLine = "    This is an indented long line that needs to be "
-    "wrapped and indentation preserved.";
+    '    This is an indented long line with newlines that\n'
+            'needs to be wrapped.\n\tAnd preserves tabs.\n      \n  ' +
+        '0123456789' * 5;
+const _shortLine = 'Short line.';
+const _indentedLongLine = '    This is an indented long line that needs to be '
+    'wrapped and indentation preserved.';
 
 void main() {
-  group("padding", () {
-    test("can pad on the right.", () {
-      expect(padRight("foo", 6), equals("foo   "));
+  group('padding', () {
+    test('can pad on the right.', () {
+      expect(padRight('foo', 6), equals('foo   '));
     });
   });
-  group("text wrapping", () {
+  group('text wrapping', () {
     test("doesn't wrap short lines.", () {
       expect(wrapText(_shortLine, length: _lineLength), equals(_shortLine));
     });
     test("doesn't wrap at all if not given a length", () {
       expect(wrapText(_longLine), equals(_longLine));
     });
-    test("able to wrap long lines", () {
-      expect(wrapText(_longLine, length: _lineLength), equals("""
+    test('able to wrap long lines', () {
+      expect(wrapText(_longLine, length: _lineLength), equals('''
 This is a long line that needs to be
-wrapped."""));
+wrapped.'''));
     });
-    test("wrap long lines with no whitespace", () {
-      expect(wrapText("0123456789" * 5, length: _lineLength), equals("""
+    test('wrap long lines with no whitespace', () {
+      expect(wrapText('0123456789' * 5, length: _lineLength), equals('''
 0123456789012345678901234567890123456789
-0123456789"""));
+0123456789'''));
     });
-    test("refuses to wrap to a column smaller than 10 characters", () {
-      expect(wrapText("$_longLine " + "0123456789" * 4, length: 1), equals("""
+    test('refuses to wrap to a column smaller than 10 characters', () {
+      expect(wrapText('$_longLine ' + '0123456789' * 4, length: 1), equals('''
 This is a
 long line
 that needs
@@ -51,88 +51,88 @@ wrapped.
 0123456789
 0123456789
 0123456789
-0123456789"""));
+0123456789'''));
     });
-    test("preserves indentation", () {
-      expect(wrapText(_indentedLongLine, length: _lineLength), equals("""
+    test('preserves indentation', () {
+      expect(wrapText(_indentedLongLine, length: _lineLength), equals('''
     This is an indented long line that
     needs to be wrapped and indentation
-    preserved."""));
+    preserved.'''));
     });
-    test("preserves indentation and stripping trailing whitespace", () {
-      expect(wrapText("$_indentedLongLine   ", length: _lineLength), equals("""
+    test('preserves indentation and stripping trailing whitespace', () {
+      expect(wrapText('$_indentedLongLine   ', length: _lineLength), equals('''
     This is an indented long line that
     needs to be wrapped and indentation
-    preserved."""));
+    preserved.'''));
     });
-    test("wraps text with newlines", () {
-      expect(wrapText(_longLineWithNewlines, length: _lineLength), equals("""
+    test('wraps text with newlines', () {
+      expect(wrapText(_longLineWithNewlines, length: _lineLength), equals('''
 This is a long line with newlines that
 needs to be wrapped.
 
 0123456789012345678901234567890123456789
-0123456789"""));
+0123456789'''));
     });
-    test("preserves indentation in the presence of newlines", () {
+    test('preserves indentation in the presence of newlines', () {
       expect(wrapText(_indentedLongLineWithNewlines, length: _lineLength),
-          equals("""
+          equals('''
     This is an indented long line with
     newlines that
 needs to be wrapped.
 \tAnd preserves tabs.
 
   01234567890123456789012345678901234567
-  890123456789"""));
+  890123456789'''));
     });
-    test("removes trailing whitespace when wrapping", () {
-      expect(wrapText("$_longLine     \t", length: _lineLength), equals("""
+    test('removes trailing whitespace when wrapping', () {
+      expect(wrapText('$_longLine     \t', length: _lineLength), equals('''
 This is a long line that needs to be
-wrapped."""));
+wrapped.'''));
     });
-    test("preserves trailing whitespace when not wrapping", () {
-      expect(wrapText("$_longLine     \t"), equals("$_longLine     \t"));
+    test('preserves trailing whitespace when not wrapping', () {
+      expect(wrapText('$_longLine     \t'), equals('$_longLine     \t'));
     });
-    test("honors hangingIndent parameter", () {
+    test('honors hangingIndent parameter', () {
       expect(
-          wrapText(_longLine, length: _lineLength, hangingIndent: 6), equals("""
+          wrapText(_longLine, length: _lineLength, hangingIndent: 6), equals('''
 This is a long line that needs to be
-      wrapped."""));
+      wrapped.'''));
     });
-    test("handles hangingIndent with a single unwrapped line.", () {
+    test('handles hangingIndent with a single unwrapped line.', () {
       expect(wrapText(_shortLine, length: _lineLength, hangingIndent: 6),
-          equals("""
-Short line."""));
+          equals('''
+Short line.'''));
     });
     test(
-        "handles hangingIndent with two unwrapped lines and the second is empty.",
+        'handles hangingIndent with two unwrapped lines and the second is empty.',
         () {
-      expect(wrapText("$_shortLine\n", length: _lineLength, hangingIndent: 6),
-          equals("""
+      expect(wrapText('$_shortLine\n', length: _lineLength, hangingIndent: 6),
+          equals('''
 Short line.
-"""));
+'''));
     });
-    test("honors hangingIndent parameter on already indented line.", () {
+    test('honors hangingIndent parameter on already indented line.', () {
       expect(wrapText(_indentedLongLine, length: _lineLength, hangingIndent: 6),
-          equals("""
+          equals('''
     This is an indented long line that
           needs to be wrapped and
-          indentation preserved."""));
+          indentation preserved.'''));
     });
-    test("honors hangingIndent parameter on already indented line.", () {
+    test('honors hangingIndent parameter on already indented line.', () {
       expect(
           wrapText(_indentedLongLineWithNewlines,
               length: _lineLength, hangingIndent: 6),
-          equals("""
+          equals('''
     This is an indented long line with
           newlines that
 needs to be wrapped.
 	And preserves tabs.
 
   01234567890123456789012345678901234567
-        890123456789"""));
+        890123456789'''));
     });
   });
-  group("text wrapping as lines", () {
+  group('text wrapping as lines', () {
     test("doesn't wrap short lines.", () {
       expect(wrapTextAsLines(_shortLine, length: _lineLength),
           equals([_shortLine]));
@@ -140,77 +140,77 @@ needs to be wrapped.
     test("doesn't wrap at all if not given a length", () {
       expect(wrapTextAsLines(_longLine), equals([_longLine]));
     });
-    test("able to wrap long lines", () {
+    test('able to wrap long lines', () {
       expect(wrapTextAsLines(_longLine, length: _lineLength),
-          equals(["This is a long line that needs to be", "wrapped."]));
+          equals(['This is a long line that needs to be', 'wrapped.']));
     });
-    test("wrap long lines with no whitespace", () {
-      expect(wrapTextAsLines("0123456789" * 5, length: _lineLength),
-          equals(["0123456789012345678901234567890123456789", "0123456789"]));
+    test('wrap long lines with no whitespace', () {
+      expect(wrapTextAsLines('0123456789' * 5, length: _lineLength),
+          equals(['0123456789012345678901234567890123456789', '0123456789']));
     });
 
-    test("refuses to wrap to a column smaller than 10 characters", () {
+    test('refuses to wrap to a column smaller than 10 characters', () {
       expect(
-          wrapTextAsLines("$_longLine " + "0123456789" * 4, length: 1),
+          wrapTextAsLines('$_longLine ' + '0123456789' * 4, length: 1),
           equals([
-            "This is a",
-            "long line",
-            "that needs",
-            "to be",
-            "wrapped.",
-            "0123456789",
-            "0123456789",
-            "0123456789",
-            "0123456789"
+            'This is a',
+            'long line',
+            'that needs',
+            'to be',
+            'wrapped.',
+            '0123456789',
+            '0123456789',
+            '0123456789',
+            '0123456789'
           ]));
     });
     test("doesn't preserve indentation", () {
       expect(
           wrapTextAsLines(_indentedLongLine, length: _lineLength),
           equals([
-            "This is an indented long line that needs",
-            "to be wrapped and indentation preserved."
+            'This is an indented long line that needs',
+            'to be wrapped and indentation preserved.'
           ]));
     });
-    test("strips trailing whitespace", () {
+    test('strips trailing whitespace', () {
       expect(
-          wrapTextAsLines("$_indentedLongLine   ", length: _lineLength),
+          wrapTextAsLines('$_indentedLongLine   ', length: _lineLength),
           equals([
-            "This is an indented long line that needs",
-            "to be wrapped and indentation preserved."
+            'This is an indented long line that needs',
+            'to be wrapped and indentation preserved.'
           ]));
     });
-    test("splits text with newlines properly", () {
+    test('splits text with newlines properly', () {
       expect(
           wrapTextAsLines(_longLineWithNewlines, length: _lineLength),
           equals([
-            "This is a long line with newlines that",
-            "needs to be wrapped.",
-            "",
-            "0123456789012345678901234567890123456789",
-            "0123456789"
+            'This is a long line with newlines that',
+            'needs to be wrapped.',
+            '',
+            '0123456789012345678901234567890123456789',
+            '0123456789'
           ]));
     });
-    test("does not preserves indentation in the presence of newlines", () {
+    test('does not preserves indentation in the presence of newlines', () {
       expect(
           wrapTextAsLines(_indentedLongLineWithNewlines, length: _lineLength),
           equals([
-            "This is an indented long line with",
-            "newlines that",
-            "needs to be wrapped.",
-            "And preserves tabs.",
-            "",
-            "0123456789012345678901234567890123456789",
-            "0123456789"
+            'This is an indented long line with',
+            'newlines that',
+            'needs to be wrapped.',
+            'And preserves tabs.',
+            '',
+            '0123456789012345678901234567890123456789',
+            '0123456789'
           ]));
     });
-    test("removes trailing whitespace when wrapping", () {
-      expect(wrapTextAsLines("$_longLine     \t", length: _lineLength),
-          equals(["This is a long line that needs to be", "wrapped."]));
+    test('removes trailing whitespace when wrapping', () {
+      expect(wrapTextAsLines('$_longLine     \t', length: _lineLength),
+          equals(['This is a long line that needs to be', 'wrapped.']));
     });
-    test("preserves trailing whitespace when not wrapping", () {
+    test('preserves trailing whitespace when not wrapping', () {
       expect(
-          wrapTextAsLines("$_longLine     \t"), equals(["$_longLine     \t"]));
+          wrapTextAsLines('$_longLine     \t'), equals(['$_longLine     \t']));
     });
   });
 }


### PR DESCRIPTION
- always_declare_return_types
- annotate_overrides
- prefer_conditional_assignment
- prefer_if_null_operators
- prefer_single_quotes
- prefer_spread_collections
- unnecessary_this
- use_function_type_syntax_for_parameters

Bump min SDK to 2.3.0 to allow spreads in collection literals.

Drop unused author field from pubspec.

Restructure a string to avoid a line over 80 characters.