### PR TITLE
Fix performance issues due to list.removeAt(0), which makes parsing O(n^2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.3
+
+* Improve performance for large numbers of args. Parsing 10k args fell from
+  250ms to 50ms; parsing 100k args fell from 15s to 100ms.
+
 ## 1.5.2
 
 * Added support for `usageLineLength` in `CommandRunner`

--- a/test/parse_performance_test.dart
+++ b/test/parse_performance_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:args/args.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ArgParser.parse()', () {
+    test('is fast', () {
+      var parser = ArgParser()..addFlag('flag');
+
+      var baseSize = 10000;
+      var baseList = List<String>.generate(baseSize, (_) => '--flag');
+
+      var multiplier = 10;
+      var largeList =
+          List<String>.generate(baseSize * multiplier, (_) => '--flag');
+      var baseTime = _time(() => parser.parse(baseList));
+      var largeTime = _time(() => parser.parse(largeList));
+      expect(largeTime, lessThan(baseTime * multiplier * 3),
+          reason:
+              'Comparing large data set time ${largeTime}ms to small data set time '
+              '${baseTime}ms. Data set increased ${multiplier}x, time is allowed to '
+              'increase up to ${multiplier * 3}x, but it increased '
+              '${largeTime ~/ baseTime}x.');
+    });
+  });
+}
+
+int _time(void Function() function) {
+  var stopwatch = Stopwatch()..start();
+  function();
+  return stopwatch.elapsedMilliseconds;
+}


### PR DESCRIPTION
Add a test that checks that parse time does not increase more than 30x when input size grows from 10k to 100k. The current increase is about x2, so this is a very loose check that should be reliably green. It will only trigger if we hit O(n^2) behaviour again.