### PR TITLE
Fix performance issues due to list.removeAt(0), which makes parsing O(n^2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.5.3
 
-* Improve performance for large numbers of args. Parsing 10k args fell from
-  250ms to 50ms; parsing 100k args fell from 15s to 100ms.
+* Improve performance for large numbers of args.
 
 ## 1.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.3
+
+* Improve performance for large numbers of args. Parsing 10k args fell from
+  250ms to 50ms; parsing 100k args fell from 15s to 100ms.
+
 ## 1.5.2
 
 * Added support for `usageLineLength` in `CommandRunner`

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'arg_parser.dart';
 import 'arg_results.dart';
 import 'option.dart';
@@ -77,7 +79,7 @@ class AllowAnythingParser implements ArgParser {
 
   @override
   ArgResults parse(Iterable<String> args) =>
-      Parser(null, this, args.toList()).parse();
+      Parser(null, this, Queue.of(args)).parse();
 
   @override
   String getUsage() => usage;

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -320,7 +320,7 @@ class ArgParser {
   /// Parses [args], a list of command-line arguments, matches them against the
   /// flags and options defined by this parser, and returns the result.
   ArgResults parse(Iterable<String> args) =>
-      Parser(null, this, args.toList()).parse();
+      Parser(null, this, Queue.of(args)).parse();
 
   /// Generates a string displaying usage information for the defined options.
   ///

--- a/test/parse_performance_test.dart
+++ b/test/parse_performance_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:args/args.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ArgParser.parse()', () {
+    test('is fast', () {
+      var parser = ArgParser()..addFlag('flag');
+
+      var baseSize = 10000;
+      var baseList = List<String>.generate(baseSize, (_) => '--flag');
+
+      var multiplier = 10;
+      var largeList =
+          List<String>.generate(baseSize * multiplier, (_) => '--flag');
+      var baseTime = _time(() => parser.parse(baseList));
+      var largeTime = _time(() => parser.parse(largeList));
+      expect(largeTime, lessThan(baseTime * multiplier * 3),
+          reason:
+              'Comparing large data set time ${largeTime}ms to small data set time '
+              '${baseTime}ms. Data set increased ${multiplier}x, time is allowed to '
+              'increase up to ${multiplier * 3}x, but it increased '
+              '${largeTime ~/ baseTime}x.');
+    });
+  });
+}
+
+int _time(void Function() function) {
+  var stopwatch = Stopwatch()..start();
+  function();
+  return stopwatch.elapsedMilliseconds;
+}

--- a/test/parse_performance_test.dart
+++ b/test/parse_performance_test.dart
@@ -10,14 +10,26 @@ void main() {
     test('is fast', () {
       var parser = ArgParser()..addFlag('flag');
 
-      var baseSize = 10000;
+      var baseSize = 200000;
       var baseList = List<String>.generate(baseSize, (_) => '--flag');
 
       var multiplier = 10;
       var largeList =
           List<String>.generate(baseSize * multiplier, (_) => '--flag');
-      var baseTime = _time(() => parser.parse(baseList));
-      var largeTime = _time(() => parser.parse(largeList));
+
+      var baseAction = () => parser.parse(baseList);
+      var largeAction = () => parser.parse(largeList);
+
+      // Warm up JIT.
+      baseAction();
+      largeAction();
+
+      var baseTime = _time(baseAction);
+      var largeTime = _time(largeAction);
+
+      print('Parsed $baseSize elements in ${baseTime}ms, '
+          '${baseSize * multiplier} elements in ${largeTime}ms.');
+
       expect(largeTime, lessThan(baseTime * multiplier * 3),
           reason:
               'Comparing large data set time ${largeTime}ms to small data set time '


### PR DESCRIPTION
Add a test that checks that parse time does not increase more than 30x when input size grows from 10k to 100k. The current increase is about x2, so this is a very loose check that should be reliably green. It will only trigger if we hit O(n^2) behaviour again.