### PR TITLE
address an issue when using ArgParser.allowAnything() with CommandRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.5.3
 
-* Improve performance for large numbers of args.
+* Improve arg parsing performance for large numbers of args.
+* No longer automatically add a 'help' option to commands that don't validate
+  their arguments (fix #123).
 
 ## 1.5.2
 

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -177,7 +177,7 @@ class CommandRunner<T> {
       commands = command._subcommands;
       commandString += ' ${argResults.name}';
 
-      if (argResults['help']) {
+      if (argResults.options.contains('help') && argResults['help']) {
         command.printUsage();
         return null;
       }
@@ -364,8 +364,10 @@ abstract class Command<T> {
   List<String> get aliases => const [];
 
   Command() {
-    argParser.addFlag('help',
-        abbr: 'h', negatable: false, help: 'Print this usage information.');
+    if (!argParser.allowsAnything) {
+      argParser.addFlag('help',
+          abbr: 'h', negatable: false, help: 'Print this usage information.');
+    }
   }
 
   /// Runs this command.

--- a/test/allow_anything_test.dart
+++ b/test/allow_anything_test.dart
@@ -3,7 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:test/test.dart';
+
+import 'test_utils.dart';
 
 void main() {
   group('new ArgParser.allowAnything()', () {
@@ -50,6 +53,14 @@ void main() {
       expect(results.command.rest, equals(['--foo', '-abc', '--', 'bar']));
       expect(results.command.arguments, equals(['--foo', '-abc', '--', 'bar']));
       expect(results.command.name, equals('command'));
+    });
+
+    test('works as a subcommand in a CommandRunner', () async {
+      var commandRunner = CommandRunner('command', 'Description of command');
+      var command = AllowAnythingCommand();
+      commandRunner..addCommand(command);
+
+      await commandRunner.run([command.name, '--foo', '--bar', '-b', 'qux']);
     });
   });
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -220,7 +220,9 @@ class AllowAnythingCommand extends Command {
   final argParser = ArgParser.allowAnything();
 
   @override
-  Future run() => Future.value().then((_) => hasRun = true);
+  void run() {
+    hasRun = true;
+  }
 }
 
 void throwsIllegalArg(function, {String reason}) {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -207,6 +207,22 @@ class AsyncCommand extends Command {
   Future run() => Future.value().then((_) => hasRun = true);
 }
 
+class AllowAnythingCommand extends Command {
+  var hasRun = false;
+
+  @override
+  final name = 'allowAnything';
+
+  @override
+  final description = 'A command using allowAnything.';
+
+  @override
+  final argParser = ArgParser.allowAnything();
+
+  @override
+  Future run() => Future.value().then((_) => hasRun = true);
+}
+
 void throwsIllegalArg(function, {String reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }


### PR DESCRIPTION
Address an issue when using `ArgParser.allowAnything()` with `CommandRunner`:
- No longer automatically add a 'help' option to commands that don't validate
  their arguments
- fix https://github.com/dart-lang/args/issues/123 (a slight variant of the PR https://github.com/dart-lang/args/pull/124)

The CommandRunner class currently doesn't work well with Commands that use an ArgParser.allowAnything() parser; this PR addresses that. It'll allow for subcommands that can do things like just delegate all arg parser (and execution) to another entity, like a subprocess.
