### PR TITLE
Allow marking commands as deprecated.

### DIFF
--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -21,7 +21,11 @@ class AllowAnythingParser implements ArgParser {
   bool get allowsAnything => true;
   @override
   int get usageLineLength => null;
-
+  @override
+  String get deprecationMessage => null;
+  @override
+  bool get isDeprecated => false;
+  
   @override
   ArgParser addCommand(String name, [ArgParser parser]) {
     throw UnsupportedError(

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -25,7 +25,7 @@ class AllowAnythingParser implements ArgParser {
   String get deprecationMessage => null;
   @override
   bool get isDeprecated => false;
-  
+
   @override
   ArgParser addCommand(String name, [ArgParser parser]) {
     throw UnsupportedError(

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -64,7 +64,10 @@ class ArgParser {
   /// flags and options that appear after positional arguments. If it's `false`,
   /// the parser stops parsing as soon as it finds an argument that is neither
   /// an option nor a command.
-  factory ArgParser({bool allowTrailingOptions = true, int usageLineLength, String deprecationMessage}) =>
+  factory ArgParser(
+          {bool allowTrailingOptions = true,
+          int usageLineLength,
+          String deprecationMessage}) =>
       ArgParser._(<String, Option>{}, <String, ArgParser>{},
           allowTrailingOptions: allowTrailingOptions,
           usageLineLength: usageLineLength,
@@ -79,16 +82,18 @@ class ArgParser {
   factory ArgParser.allowAnything() = AllowAnythingParser;
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
-      {bool allowTrailingOptions = true, this.usageLineLength, this.deprecationMessage})
+      {bool allowTrailingOptions = true,
+      this.usageLineLength,
+      this.deprecationMessage})
       : _options = options,
         options = UnmodifiableMapView(options),
         _commands = commands,
         commands = UnmodifiableMapView(commands),
         allowTrailingOptions = allowTrailingOptions ?? false {
-          if (deprecationMessage != null && deprecationMessage.isNotEmpty){
-            _optionsAndSeparators.add('Deprecation Message: $deprecationMessage');
-          }
-        }
+    if (deprecationMessage != null && deprecationMessage.isNotEmpty) {
+      _optionsAndSeparators.add('Deprecation Message: $deprecationMessage');
+    }
+  }
 
   /// Defines a command.
   ///

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -50,16 +50,25 @@ class ArgParser {
   /// arguments.
   bool get allowsAnything => false;
 
+  /// Whether this commands will be deprecated in the future.
+  /// Only in case of Commands.
+  bool get isDeprecated =>
+      deprecationMessage != null && deprecationMessage.isNotEmpty;
+
+  /// The message to be displayed when a deprecated command is used.
+  final String deprecationMessage;
+
   /// Creates a new ArgParser.
   ///
   /// If [allowTrailingOptions] is `true` (the default), the parser will parse
   /// flags and options that appear after positional arguments. If it's `false`,
   /// the parser stops parsing as soon as it finds an argument that is neither
   /// an option nor a command.
-  factory ArgParser({bool allowTrailingOptions = true, int usageLineLength}) =>
+  factory ArgParser({bool allowTrailingOptions = true, int usageLineLength, String deprecationMessage}) =>
       ArgParser._(<String, Option>{}, <String, ArgParser>{},
           allowTrailingOptions: allowTrailingOptions,
-          usageLineLength: usageLineLength);
+          usageLineLength: usageLineLength,
+          deprecationMessage: deprecationMessage);
 
   /// Creates a new ArgParser that treats *all input* as non-option arguments.
   ///
@@ -70,7 +79,7 @@ class ArgParser {
   factory ArgParser.allowAnything() = AllowAnythingParser;
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
-      {bool allowTrailingOptions = true, this.usageLineLength})
+      {bool allowTrailingOptions = true, this.usageLineLength, this.deprecationMessage})
       : _options = options,
         options = UnmodifiableMapView(options),
         _commands = commands,

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -84,7 +84,11 @@ class ArgParser {
         options = UnmodifiableMapView(options),
         _commands = commands,
         commands = UnmodifiableMapView(commands),
-        allowTrailingOptions = allowTrailingOptions ?? false;
+        allowTrailingOptions = allowTrailingOptions ?? false {
+          if (deprecationMessage != null && deprecationMessage.isNotEmpty){
+            _optionsAndSeparators.add('Deprecation Message: $deprecationMessage');
+          }
+        }
 
   /// Defines a command.
   ///

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -70,6 +70,10 @@ class Parser {
       if (command != null) {
         validate(rest.isEmpty, 'Cannot specify arguments before a command.');
         var commandName = args.removeFirst();
+        if (command.isDeprecated) {
+          print(command.deprecationMessage);
+        }
+
         var commandParser = Parser(commandName, command, args, this, rest);
 
         try {

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -71,7 +71,7 @@ class Parser {
         validate(rest.isEmpty, 'Cannot specify arguments before a command.');
         var commandName = args.removeFirst();
         if (command.isDeprecated) {
-          print(command.deprecationMessage);
+          print('Deprecation Warning: ${command.deprecationMessage}');
         }
 
         var commandParser = Parser(commandName, command, args, this, rest);

--- a/test/args_test.dart
+++ b/test/args_test.dart
@@ -176,6 +176,19 @@ void main() {
     });
   });
 
+  group('ArgParser.isDeprecated', () {
+    test('returns the correct value for isDeprecate', () {
+      var parser = ArgParser(deprecationMessage: 'command deprecated.');
+      expect(parser.isDeprecated, true);
+      expect(parser.deprecationMessage, isNotNull);
+    });
+    test('returns false value for isDeprecate when empty message is given', () {
+      var parser = ArgParser(deprecationMessage: '');
+      expect(parser.isDeprecated, false);
+      expect(parser.deprecationMessage, isNotNull);
+    });
+  });
+
   group('ArgParser.options', () {
     test('returns an empty map if there are no options', () {
       var parser = ArgParser();


### PR DESCRIPTION
This pull request fixes #125 .
We can pass an argument to an ArgParser to mark that command as deprecated, which will show warning when used.