### PR TITLE
Remove extra blank lines between options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.5.3-dev
+## 1.6.0
+
+* Remove the blank lines in usage which separated the help for options that
+  happened to span multiple lines.
+
+## 1.5.3
 
 * Improve arg parsing performance: use queues instead of lists internally to
   get linear instead of quadratic performance, which is important for large

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -112,12 +112,6 @@ class Usage {
           write(2, '(defaults to "${option.defaultsTo}")');
         }
       }
-
-      // If any given option displays more than one line of text on the right
-      // column (i.e. help, default value, allowed options, etc.) then put a
-      // blank line after it. This gives space where it's useful while still
-      // keeping simple one-line options clumped together.
-      if (numHelpLines > 1) newline();
     }
 
     return buffer.toString();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 1.5.3
+version: 1.6.0-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -96,7 +96,6 @@ void main() {
       validateUsage(parser, '''
           --[no-]affirm    Should be on
                            (defaults to on)
-
           --[no-]negate    Should be off
           --[no-]null      Should be null
           ''');
@@ -118,10 +117,8 @@ void main() {
       validateUsage(parser, '''
           --single         Can be anything
                            (defaults to "whatevs")
-
           --multiple       Can be anything
                            (defaults to "whatevs")
-
           --allow-multi    Can be anything
                            (defaults to "whatevs")
           ''');
@@ -354,22 +351,17 @@ void main() {
       validateUsage(parser, '''
           --[no-]long              The flag with a really long help
                                    text that will be wrapped.
-          
           --[no-]longNewline       The flag with a really long help
                                    text and newlines
                                    
                                    that will still be wrapped because
                                    it is really long.
-          
           --[no-]solid             The-flag-with-no-whitespace-that-wi
                                    ll-be-wrapped-by-splitting-a-word.
-          
           --[no-]longWhitespace    The flag with a really long help
                                    text and whitespace at the start.
-          
           --[no-]longTrailspace    The flag with a really long help
                                    text and whitespace at the end.
-          
           --[no-]small1            a
           --[no-]small2            a
           --[no-]small3            a
@@ -400,7 +392,6 @@ void main() {
                                 text that
                                 will be
                                 wrapped.
-          
           --[no-]longNewline    The flag
                                 with a
                                 really
@@ -414,7 +405,6 @@ void main() {
                                 because it
                                 is really
                                 long.
-          
           --[no-]solid          The-flag-w
                                 ith-no-whi
                                 tespace-th
@@ -422,7 +412,6 @@ void main() {
                                 -wrapped-b
                                 y-splittin
                                 g-a-word.
-          
           --[no-]small1         a
           --[no-]small2         a
           --[no-]small3         a


### PR DESCRIPTION
Fixes #48

The extra blank lines imply a grouping, however the grouping is
arbitrary based on which options happened to wrap, and may vary based on
the terminal width. Instead keep all options without extra newlines.