### PR TITLE
Reference CommandRunner from addCommand docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.5.4-dev
 
+* Point towards `CommandRunner` in the docs for `ArgParser.addCommand` since it
+  is what most authors will want to use instead.
+
 ## 1.5.3
 
 * Improve arg parsing performance: use queues instead of lists internally to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.5.3-dev
+## 1.5.4-dev
+
+## 1.5.3
 
 * Improve arg parsing performance: use queues instead of lists internally to
   get linear instead of quadratic performance, which is important for large

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -8,7 +8,6 @@
 
 import 'dart:collection';
 
-import '../command_runner.dart';
 import 'allow_anything_parser.dart';
 import 'arg_results.dart';
 import 'option.dart';
@@ -85,7 +84,7 @@ class ArgParser {
   /// creates a new one. Returns the parser for the command.
   ///
   /// Note that adding commands this way will not impact the [usage] string. To
-  /// add commands which are included in the usage string see [CommandRunner].
+  /// add commands which are included in the usage string see `CommandRunner`.
   ArgParser addCommand(String name, [ArgParser parser]) {
     // Make sure the name isn't in use.
     if (_commands.containsKey(name)) {

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -8,6 +8,7 @@
 
 import 'dart:collection';
 
+import '../command_runner.dart';
 import 'allow_anything_parser.dart';
 import 'arg_results.dart';
 import 'option.dart';
@@ -82,6 +83,9 @@ class ArgParser {
   /// A command is a named argument which may in turn define its own options and
   /// subcommands using the given parser. If [parser] is omitted, implicitly
   /// creates a new one. Returns the parser for the command.
+  ///
+  /// Note that adding commands this way will not impact the [usage] string. To
+  /// add commands which are included in the usage string see [CommandRunner].
   ArgParser addCommand(String name, [ArgParser parser]) {
     // Make sure the name isn't in use.
     if (_commands.containsKey(name)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 1.5.3
+version: 1.5.4-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set


### PR DESCRIPTION
Closes #134

The `addCommand` API is a little confusing, it doesn't impact the usage
string the way you might expect.

In the future we might consider hiding this API, for now call out the
confusing aspect and point to the API that most folks should use.