### PR TITLE
Remove help from the list of commands in usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.5.4-dev
+## 1.6.0-dev
 
 * Point towards `CommandRunner` in the docs for `ArgParser.addCommand` since it
   is what most authors will want to use instead.
+* Remove `help` from the list of commands in usage.
 
 ## 1.5.3
 

--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -19,6 +19,9 @@ class HelpCommand<T> extends Command<T> {
   String get invocation => '${runner.executableName} help [command]';
 
   @override
+  bool get hidden => true;
+
+  @override
   T run() {
     // Show the default help if no command was specified.
     if (argResults.rest.isEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 1.5.4-dev
+version: 1.6.0-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -48,8 +48,7 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
-  foo    Set a value.
-  help   Display help information for test.
+  foo   Set a value.
 
 Run "test help <command>" for more information about a command.'''));
     });
@@ -66,7 +65,6 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
-  help        Display help information for test.
   multiline   Multi
 
 Run "test help <command>" for more information about a command.'''));
@@ -84,7 +82,6 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
-  help        Display help information for test.
   multiline   Multi
               line.
 
@@ -110,12 +107,20 @@ Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
-      runner.addCommand(HiddenCommand());
+      runner..addCommand(HiddenCommand())..addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.
 
-$_defaultUsage'''));
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+  foo   Set a value.
+
+Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print aliases", () {
@@ -131,7 +136,6 @@ Global options:
 
 Available commands:
   aliased   Set a value.
-  help      Display help information for test.
 
 Run "test help <command>" for more information about a command.'''));
     });
@@ -428,8 +432,7 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
-  foo    Set a value.
-  help   Display help information for test.
+  foo   Set a value.
 
 Run "test help <command>" for more information about a command.'''));
     });


### PR DESCRIPTION
Closes #131

The `help` command is redundant against the bottom line of the usage
text which explains how to use help in a more understandable way.