### PR TITLE
null safety cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       name: "Analyze (with experiment flag)"
       dart: dev
       os: linux
-      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
+      script: dartanalyzer --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
       dart: dev
@@ -24,12 +24,12 @@ jobs:
       name: "Vm Tests"
       dart: dev
       os: linux
-      script: pub run --enable-experiment=non-nullable test -p vm
+      script: pub run test -p vm
     - stage: test
       name: "Web Tests"
       dart: dev
       os: linux
-      script: pub run --enable-experiment=non-nullable test -p chrome
+      script: pub run test -p chrome
 
 matrix:
   include:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,88 +9,11 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.4.0
-  test: '^1.5.1'
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.9
 
+# Required to get a version solve due to cyclic dependency
 dependency_overrides:
-  async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
-  boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
-  charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-  matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-  path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
-  pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
-  pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
-  source_maps:
-    git:
-      url: git://github.com/dart-lang/source_maps.git
-      ref: null_safety
-  source_map_stack_trace:
-    git:
-      url: git://github.com/dart-lang/source_map_stack_trace.git
-      ref: null_safety
-  source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
-  stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
-  stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
-  string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
-  term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test
+  test_core: ^0.3.12-nullsafety.9
+  coverage: ">=0.13.4 <0.15.0"
+  analyzer: ">=0.39.5 <0.41.0"

--- a/test/allow_anything_test.dart
+++ b/test/allow_anything_test.dart
@@ -51,7 +51,8 @@ void main() {
           commandParser.parse(['command', '--foo', '-abc', '--', 'bar']);
       expect(results.command!.options, isEmpty);
       expect(results.command!.rest, equals(['--foo', '-abc', '--', 'bar']));
-      expect(results.command!.arguments, equals(['--foo', '-abc', '--', 'bar']));
+      expect(
+          results.command!.arguments, equals(['--foo', '-abc', '--', 'bar']));
       expect(results.command!.name, equals('command'));
     });
 

--- a/test/args_test.dart
+++ b/test/args_test.dart
@@ -309,8 +309,8 @@ void main() {
           parser.options['allow-multi-no']!.getOrDefault(['v']), equals(['v']));
       expect(parser.options['allow-multi-def']!.getOrDefault(null),
           equals(['def']));
-      expect(
-          parser.options['allow-multi-def']!.getOrDefault(['v']), equals(['v']));
+      expect(parser.options['allow-multi-def']!.getOrDefault(['v']),
+          equals(['v']));
       expect(parser.options['multi-no']!.getOrDefault(null), equals([]));
       expect(parser.options['multi-no']!.getOrDefault(['v']), equals(['v']));
       expect(parser.options['multi-def']!.getOrDefault(null), equals(['def']));

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -154,12 +154,11 @@ void main() {
       });
 
       test('are invoked even if the option is not present', () {
-        var a = 'not called';
         var parser = ArgParser();
-        parser.addOption('a', callback: (value) => a = value);
+        parser.addOption('a',
+            callback: expectAsync1((value) => expect(value, isNull)));
 
         parser.parse([]);
-        expect(a, isNull);
       });
 
       group('with allowMultiple', () {

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -353,7 +353,7 @@ void main() {
                                    text that will be wrapped.
           --[no-]longNewline       The flag with a really long help
                                    text and newlines
-
+                                   
                                    that will still be wrapped because
                                    it is really long.
           --[no-]solid             The-flag-with-no-whitespace-that-wi
@@ -398,7 +398,7 @@ void main() {
                                 long help
                                 text and
                                 newlines
-
+                                
                                 that will
                                 still be
                                 wrapped


### PR DESCRIPTION
* update sdk constraints and deps
* remove experiment flags from CI
* fix some tests

Note that I had already pushed an update to bump the version to 2.0.0-nullsafety. Feel free to push back on that here.