### PR TITLE
Simplify throwsUsageException matcher util

### DIFF
--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -231,11 +231,7 @@ void throwsFormat(ArgParser parser, List<String> args) {
   expect(() => parser.parse(args), throwsFormatException);
 }
 
-Matcher throwsUsageException(message, usage) {
-  return throwsA(predicate((dynamic error) {
-    expect(error, TypeMatcher<UsageException>());
-    expect(error.message, message);
-    expect(error.usage, usage);
-    return true;
-  }));
-}
+Matcher throwsUsageException(String message, String usage) =>
+    throwsA(isA<UsageException>()
+        .having((e) => e.message, 'message', message)
+        .having((e) => e.usage, 'usage', usage));


### PR DESCRIPTION
- Use `having` chain from the `TypeMatcher` rather than wrap in a
  predicate with calls to `expect`.
- Add static types to arguments.
- Switch from `TypeMatcher` constructor to `isA` method.