### PR TITLE
Use Null as return type for HelpCommand.run

### DIFF
--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -22,11 +22,11 @@ class HelpCommand<T> extends Command<T> {
   bool get hidden => true;
 
   @override
-  T? run() {
+  Null run() {
     // Show the default help if no command was specified.
     if (argResults!.rest.isEmpty) {
       runner!.printUsage();
-      return null;
+      return;
     }
 
     // Walk the command tree to show help for the selected command or
@@ -56,6 +56,5 @@ class HelpCommand<T> extends Command<T> {
     }
 
     command!.printUsage();
-    return null;
   }
 }


### PR DESCRIPTION
This may make it easier to understand choices around nullability by
making it explicit that the help command can never return a useful value
from it's `run` method.

Remove the unnecessary return value and return statement since a `Null`
return type may be treated similarly to `void`.