### PR TITLE
Refactor usage.dart

### DIFF
--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -304,7 +304,7 @@ class ArgParser {
   ///
   /// This is basically the help text shown on the command line.
   String get usage {
-    return Usage(_optionsAndSeparators, lineLength: usageLineLength).generate();
+    return generateUsage(_optionsAndSeparators, lineLength: usageLineLength);
   }
 
   /// Get the default value for an option. Useful after parsing to test if the

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -7,8 +7,7 @@ import 'dart:math' as math;
 import '../args.dart';
 import 'utils.dart';
 
-/// Takes an [ArgParser] and generates a string of usage (i.e. help) text for
-/// its defined options.
+/// Generates a string of usage (i.e. help) text for a list of options.
 ///
 /// Internally, it works like a tabular printer. The output is divided into
 /// three horizontal columns, like so:
@@ -18,32 +17,27 @@ import 'utils.dart';
 ///
 /// It builds the usage text up one column at a time and handles padding with
 /// spaces and wrapping to the next line to keep the cells correctly lined up.
-class Usage {
+String generateUsage(List optionsAndSeparators, {int? lineLength}) =>
+    _Usage(optionsAndSeparators, lineLength).generate();
+
+class _Usage {
   /// Abbreviation, long name, help.
   static const _columnCount = 3;
 
   /// A list of the [Option]s intermingled with [String] separators.
-  final List optionsAndSeparators;
+  final List _optionsAndSeparators;
 
   /// The working buffer for the generated usage text.
-  late StringBuffer buffer;
+  final _buffer = StringBuffer();
 
   /// The column that the "cursor" is currently on.
   ///
   /// If the next call to [write()] is not for this column, it will correctly
   /// handle advancing to the next column (and possibly the next row).
-  int currentColumn = 0;
+  int _currentColumn = 0;
 
   /// The width in characters of each column.
-  late List<int> columnWidths;
-
-  /// The number of sequential lines of text that have been written to the last
-  /// column (which shows help info).
-  ///
-  /// We track this so that help text that spans multiple lines can be padded
-  /// with a blank line after it for separation. Meanwhile, sequential options
-  /// with single-line help will be compacted next to each other.
-  int numHelpLines = 0;
+  late final _columnWidths = _calculateLineWidths();
 
   /// How many newlines need to be rendered before the next bit of text can be
   /// written.
@@ -51,76 +45,79 @@ class Usage {
   /// We do this lazily so that the last bit of usage doesn't have dangling
   /// newlines. We only write newlines right *before* we write some real
   /// content.
-  int newlinesNeeded = 0;
+  int _newlinesNeeded = 0;
 
-  /// The horizontal character position at which help text is wrapped. Help that
-  /// extends past this column will be wrapped at the nearest whitespace (or
-  /// truncated if there is no available whitespace).
+  /// The horizontal character position at which help text is wrapped.
+  ///
+  /// Help that extends past this column will be wrapped at the nearest
+  /// whitespace (or truncated if there is no available whitespace).
   final int? lineLength;
 
-  Usage(this.optionsAndSeparators, {this.lineLength});
+  _Usage(this._optionsAndSeparators, this.lineLength);
 
   /// Generates a string displaying usage information for the defined options.
   /// This is basically the help text shown on the command line.
   String generate() {
-    buffer = StringBuffer();
-
-    calculateColumnWidths();
-
-    for (var optionOrSeparator in optionsAndSeparators) {
+    for (var optionOrSeparator in _optionsAndSeparators) {
       if (optionOrSeparator is String) {
-        // Ensure that there's always a blank line before a separator.
-        if (buffer.isNotEmpty) buffer.write('\n\n');
-        buffer.write(optionOrSeparator);
-        newlinesNeeded = 1;
+        _writeSeparator(optionOrSeparator);
         continue;
       }
-
       var option = optionOrSeparator as Option;
       if (option.hide) continue;
-
-      write(0, getAbbreviation(option));
-      write(1, getLongOption(option));
-
-      if (option.help != null) write(2, option.help!);
-
-      if (option.allowedHelp != null) {
-        var allowedNames = option.allowedHelp!.keys.toList(growable: false);
-        allowedNames.sort();
-        newline();
-        for (var name in allowedNames) {
-          write(1, getAllowedTitle(option, name));
-          write(2, option.allowedHelp![name]!);
-        }
-        newline();
-      } else if (option.allowed != null) {
-        write(2, buildAllowedList(option));
-      } else if (option.isFlag) {
-        if (option.defaultsTo == true) {
-          write(2, '(defaults to on)');
-        }
-      } else if (option.isMultiple) {
-        if (option.defaultsTo != null && option.defaultsTo.isNotEmpty) {
-          write(
-              2,
-              '(defaults to ' +
-                  option.defaultsTo.map((value) => '"$value"').join(', ') +
-                  ')');
-        }
-      } else {
-        if (option.defaultsTo != null) {
-          write(2, '(defaults to "${option.defaultsTo}")');
-        }
-      }
+      _writeOption(option);
     }
 
-    return buffer.toString();
+    return _buffer.toString();
   }
 
-  String getAbbreviation(Option option) =>
+  void _writeSeparator(String separator) {
+    // Ensure that there's always a blank line before a separator.
+    if (_buffer.isNotEmpty) _buffer.write('\n\n');
+    _buffer.write(separator);
+    _newlinesNeeded = 1;
+  }
+
+  void _writeOption(Option option) {
+    _write(0, _abbreviation(option));
+    _write(1, _longOption(option));
+
+    if (option.help != null) _write(2, option.help!);
+
+    if (option.allowedHelp != null) {
+      var allowedNames = option.allowedHelp!.keys.toList(growable: false);
+      allowedNames.sort();
+      _newline();
+      for (var name in allowedNames) {
+        _write(1, _allowedTitle(option, name));
+        _write(2, option.allowedHelp![name]!);
+      }
+      _newline();
+    } else if (option.allowed != null) {
+      _write(2, _buildAllowedList(option));
+    } else if (option.isFlag) {
+      if (option.defaultsTo == true) {
+        _write(2, '(defaults to on)');
+      }
+    } else if (option.isMultiple) {
+      if (option.defaultsTo != null && option.defaultsTo.isNotEmpty) {
+        _write(
+            2,
+            '(defaults to ' +
+                option.defaultsTo.map((value) => '"$value"').join(', ') +
+                ')');
+      }
+    } else {
+      if (option.defaultsTo != null) {
+        _write(2, '(defaults to "${option.defaultsTo}")');
+      }
+    }
+  }
+
+  String _abbreviation(Option option) =>
       option.abbr == null ? '' : '-${option.abbr}, ';
 
-  String getLongOption(Option option) {
+  String _longOption(Option option) {
     var result;
     if (option.negatable!) {
       result = '--[no-]${option.name}';
@@ -133,118 +130,103 @@ class Usage {
     return result;
   }
 
-  String getAllowedTitle(Option option, String allowed) {
+  String _allowedTitle(Option option, String allowed) {
     var isDefault = option.defaultsTo is List
         ? option.defaultsTo.contains(allowed)
         : option.defaultsTo == allowed;
     return '      [$allowed]' + (isDefault ? ' (default)' : '');
   }
 
-  void calculateColumnWidths() {
+  List<int> _calculateLineWidths() {
     var abbr = 0;
     var title = 0;
-    for (var option in optionsAndSeparators) {
+    for (var option in _optionsAndSeparators) {
       if (option is! Option) continue;
       if (option.hide) continue;
 
       // Make room in the first column if there are abbreviations.
-      abbr = math.max(abbr, getAbbreviation(option).length);
+      abbr = math.max(abbr, _abbreviation(option).length);
 
       // Make room for the option.
-      title = math.max(title, getLongOption(option).length);
+      title = math.max(title, _longOption(option).length);
 
       // Make room for the allowed help.
       if (option.allowedHelp != null) {
         for (var allowed in option.allowedHelp!.keys) {
-          title = math.max(title, getAllowedTitle(option, allowed).length);
+          title = math.max(title, _allowedTitle(option, allowed).length);
         }
       }
     }
 
     // Leave a gutter between the columns.
     title += 4;
-    columnWidths = [abbr, title];
+    return [abbr, title];
   }
 
-  void newline() {
-    newlinesNeeded++;
-    currentColumn = 0;
-    numHelpLines = 0;
+  void _newline() {
+    _newlinesNeeded++;
+    _currentColumn = 0;
   }
 
-  void write(int column, String text) {
+  void _write(int column, String text) {
     var lines = text.split('\n');
     // If we are writing the last column, word wrap it to fit.
-    if (column == columnWidths.length && lineLength != null) {
-      var wrappedLines = <String>[];
-      var start = columnWidths
-          .sublist(0, column)
-          .reduce((start, width) => start += width);
-
-      for (var line in lines) {
-        wrappedLines
-            .addAll(wrapTextAsLines(line, start: start, length: lineLength));
-      }
-
-      lines = wrappedLines;
+    if (column == _columnWidths.length && lineLength != null) {
+      var start =
+          _columnWidths.take(column).reduce((start, width) => start + width);
+      lines = [
+        for (var line in lines)
+          ...wrapTextAsLines(line, start: start, length: lineLength),
+      ];
     }
 
     // Strip leading and trailing empty lines.
-    while (lines.isNotEmpty && lines[0].trim() == '') {
-      lines.removeRange(0, 1);
+    while (lines.isNotEmpty && lines.first.trim() == '') {
+      lines.removeAt(0);
     }
-
-    while (lines.isNotEmpty && lines[lines.length - 1].trim() == '') {
+    while (lines.isNotEmpty && lines.last.trim() == '') {
       lines.removeLast();
     }
 
     for (var line in lines) {
-      writeLine(column, line);
+      _writeLine(column, line);
     }
   }
 
-  void writeLine(int column, String text) {
+  void _writeLine(int column, String text) {
     // Write any pending newlines.
-    while (newlinesNeeded > 0) {
-      buffer.write('\n');
-      newlinesNeeded--;
+    while (_newlinesNeeded > 0) {
+      _buffer.write('\n');
+      _newlinesNeeded--;
     }
 
     // Advance until we are at the right column (which may mean wrapping around
     // to the next line.
-    while (currentColumn != column) {
-      if (currentColumn < _columnCount - 1) {
-        buffer.write(' ' * columnWidths[currentColumn]);
+    while (_currentColumn != column) {
+      if (_currentColumn < _columnCount - 1) {
+        _buffer.write(' ' * _columnWidths[_currentColumn]);
       } else {
-        buffer.write('\n');
+        _buffer.write('\n');
       }
-      currentColumn = (currentColumn + 1) % _columnCount;
+      _currentColumn = (_currentColumn + 1) % _columnCount;
     }
 
-    if (column < columnWidths.length) {
+    if (column < _columnWidths.length) {
       // Fixed-size column, so pad it.
-      buffer.write(text.padRight(columnWidths[column]));
+      _buffer.write(text.padRight(_columnWidths[column]));
     } else {
       // The last column, so just write it.
-      buffer.write(text);
+      _buffer.write(text);
     }
 
     // Advance to the next column.
-    currentColumn = (currentColumn + 1) % _columnCount;
+    _currentColumn = (_currentColumn + 1) % _columnCount;
 
     // If we reached the last column, we need to wrap to the next line.
-    if (column == _columnCount - 1) newlinesNeeded++;
-
-    // Keep track of how many consecutive lines we've written in the last
-    // column.
-    if (column == _columnCount - 1) {
-      numHelpLines++;
-    } else {
-      numHelpLines = 0;
-    }
+    if (column == _columnCount - 1) _newlinesNeeded++;
   }
 
-  String buildAllowedList(Option option) {
+  String _buildAllowedList(Option option) {
     var isDefault = option.defaultsTo is List
         ? option.defaultsTo.contains
         : (value) => value == option.defaultsTo;


### PR DESCRIPTION
- Add a top level method rather than require a constructor call and call
  to `generate()` when there is otherwise no reason to hold on to the
  `Usage` object. This makes it more clear that the implementation is
  following a method object pattern.
- Update doc comment which had drifted from the original implementation
  and no longer referred to the correct arguments.
- Make the `StringBuffer` field final since it is now a guaranteed
  single use object.
- Make everything possible private. This revealed that there was a field
  being updated but never read and can be removed.
- Remove `get` from method names.
- Make the `_columnWidths` late final rather than initialize it manually
  in the call to `generate()`.
- Pull out sub-methods `_writeSeparator` and `_writeOption` from
  `generate` to reduce nesting and the length of the overall method.
- use `.take(size)` instead of `.sublist(size)` since we only need an
  Iterable.
- Use `.first` and `.last` over manual indexing.
- Use `.removeAt(0)` over `.removeRange(0,1)`.
- Rewrite a for loop with `.addAll` calls to a List literal with a
  for loop element.