### PR TITLE
Fix link to use https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@
 * Allow option values that look like options. This more closely matches the
   behavior of [`getopt`][getopt], the *de facto* standard for option parsing.
 
-[getopt]: http://man7.org/linux/man-pages/man3/getopt.3.html
+[getopt]: https://man7.org/linux/man-pages/man3/getopt.3.html
 
 ## 0.13.1
 


### PR DESCRIPTION
This package could have more [Pub points](https://pub.dev/packages/args/score) if we fix this issue:

> Links in `CHANGELOG.md` should be secure. 1 link is insecure.
