### PR TITLE
Re-expose the class OptionType

### DIFF
--- a/lib/args.dart
+++ b/lib/args.dart
@@ -5,4 +5,4 @@
 export 'src/arg_parser.dart' show ArgParser;
 export 'src/arg_parser_exception.dart' show ArgParserException;
 export 'src/arg_results.dart' show ArgResults;
-export 'src/option.dart' show Option;
+export 'src/option.dart' show Option, OptionType;


### PR DESCRIPTION
This was hidden in #147 but it is used by some external packages and
there is no strong reason to make this an additional breaking change.