### PR TITLE
Add support for argument name aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0
+
+* Add `aliases` named argument to `addFlag`, `addOption`, and `addMultiOption`,
+  as well as a public `findByNameOrAlias` method on `ArgParser`. This allows
+  you to provide aliases for an argument name, which eases the transition from
+  one argument name to another.
+
 ## 2.0.0
 
 * Stable null safety release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0
+## 2.1.0-dev
 
 * Add `aliases` named argument to `addFlag`, `addOption`, and `addMultiOption`,
   as well as a public `findByNameOrAlias` method on `ArgParser`. This allows

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -35,7 +35,8 @@ class AllowAnythingParser implements ArgParser {
       bool? defaultsTo = false,
       bool negatable = true,
       void Function(bool)? callback,
-      bool hide = false}) {
+      bool hide = false,
+      List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addFlag() isn't supported.");
   }
@@ -51,7 +52,8 @@ class AllowAnythingParser implements ArgParser {
       void Function(String?)? callback,
       bool allowMultiple = false,
       bool? splitCommas,
-      bool hide = false}) {
+      bool hide = false,
+      List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addOption() isn't supported.");
   }
@@ -66,7 +68,8 @@ class AllowAnythingParser implements ArgParser {
       Iterable<String>? defaultsTo,
       void Function(List<String>)? callback,
       bool splitCommas = true,
-      bool hide = false}) {
+      bool hide = false,
+      List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addMultiOption() isn't supported.");
   }
@@ -96,4 +99,7 @@ class AllowAnythingParser implements ArgParser {
 
   @override
   Option? findByAbbreviation(String abbr) => null;
+
+  @override
+  Option? findByNameOrAlias(String name) => null;
 }

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -285,7 +285,8 @@ class ArgParser {
       bool? splitCommas,
       bool hide = false,
       List<String> aliases = const []}) {
-    if (findByNameOrAlias(name) != null) {
+    var allNames = [name, ...aliases];
+    if (allNames.any((name) => findByNameOrAlias(name) != null)) {
       throw ArgumentError('Duplicate option or alias "$name".');
     }
 

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -18,10 +18,14 @@ Option newOption(
     OptionType type,
     {bool? negatable,
     bool? splitCommas,
-    bool hide = false}) {
+    bool hide = false,
+    List<String> aliases = const []}) {
   return Option._(name, abbr, help, valueHelp, allowed, allowedHelp, defaultsTo,
       callback, type,
-      negatable: negatable, splitCommas: splitCommas, hide: hide);
+      negatable: negatable,
+      splitCommas: splitCommas,
+      hide: hide,
+      aliases: aliases);
 }
 
 /// A command-line option.
@@ -73,6 +77,9 @@ class Option {
   /// Whether this option should be hidden from usage documentation.
   final bool hide;
 
+  /// All aliases for [name].
+  final List<String> aliases;
+
   /// Whether the option is boolean-valued flag.
   bool get isFlag => type == OptionType.flag;
 
@@ -94,7 +101,8 @@ class Option {
       OptionType type,
       {this.negatable,
       bool? splitCommas,
-      this.hide = false})
+      this.hide = false,
+      this.aliases = const []})
       : allowed = allowed == null ? null : List.unmodifiable(allowed),
         allowedHelp =
             allowedHelp == null ? null : Map.unmodifiable(allowedHelp),

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -243,9 +243,6 @@ class Parser {
       return false;
     }
 
-    // Retrieve the option by its real name, if this is an alias. We don't
-    // overwrite `name` so that future messages map to the user provided
-    // name.
     var option = grammar.findByNameOrAlias(name);
     if (option != null) {
       args.removeFirst();

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -243,7 +243,10 @@ class Parser {
       return false;
     }
 
-    var option = grammar.options[name];
+    // Retrieve the option by its real name, if this is an alias. We don't
+    // overwrite `name` so that future messages map to the user provided
+    // name.
+    var option = grammar.findByNameOrAlias(name);
     if (option != null) {
       args.removeFirst();
       if (option.isFlag) {
@@ -261,7 +264,7 @@ class Parser {
     } else if (name.startsWith('no-')) {
       // See if it's a negated flag.
       name = name.substring('no-'.length);
-      option = grammar.options[name];
+      option = grammar.findByNameOrAlias(name);
       if (option == null) {
         // Walk up to the parent command if possible.
         validate(parent != null, 'Could not find an option named "$name".');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.1.0
+version: 2.1.0-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/test/args_test.dart
+++ b/test/args_test.dart
@@ -184,6 +184,40 @@ void main() {
     });
   });
 
+  group('ArgParser.findByNameOrAlias', () {
+    test('returns null if there is no match', () {
+      var parser = ArgParser();
+      expect(parser.findByNameOrAlias('a'), isNull);
+    });
+
+    test('can find options by alias', () {
+      var parser = ArgParser()..addOption('a', aliases: ['b']);
+      expect(parser.findByNameOrAlias('b'),
+          isA<Option>().having((o) => o.name, 'name', 'a'));
+    });
+
+    test('can find flags by alias', () {
+      var parser = ArgParser()..addFlag('a', aliases: ['b']);
+      expect(parser.findByNameOrAlias('b'),
+          isA<Option>().having((o) => o.name, 'name', 'a'));
+    });
+
+    test('does not allow duplicate aliases', () {
+      var parser = ArgParser()..addOption('a', aliases: ['b']);
+      throwsIllegalArg(() => parser.addOption('c', aliases: ['b']));
+    });
+
+    test('does not allow aliases that conflict with existing names', () {
+      var parser = ArgParser()..addOption('a', aliases: ['b']);
+      throwsIllegalArg(() => parser.addOption('c', aliases: ['a']));
+    });
+
+    test('does not allow names that conflict with existing aliases', () {
+      var parser = ArgParser()..addOption('a', aliases: ['b']);
+      throwsIllegalArg(() => parser.addOption('b'));
+    });
+  });
+
   group('ArgResults', () {
     group('options', () {
       test('returns the provided options', () {

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -70,6 +70,19 @@ void main() {
         var results = parser.parse(['--$allCharacters']);
         expect(results[allCharacters], isTrue);
       });
+
+      test('can match by alias', () {
+        var parser = ArgParser()..addFlag('a', aliases: ['b']);
+        var results = parser.parse(['--b']);
+        expect(results['a'], isTrue);
+      });
+
+      test('can be negated by alias', () {
+        var parser = ArgParser()
+          ..addFlag('a', aliases: ['b'], defaultsTo: true, negatable: true);
+        var results = parser.parse(['--no-b']);
+        expect(results['a'], isFalse);
+      });
     });
 
     group('flags negated with "no-"', () {
@@ -244,6 +257,12 @@ void main() {
 
           parser.parse(['--a=v,w', '--a=x']);
           expect(a, equals(['v', 'w', 'x']));
+        });
+
+        test('can mix and match alias and regular name', () {
+          var parser = ArgParser()..addMultiOption('a', aliases: ['b']);
+          var results = parser.parse(['--a=1', '--b=2']);
+          expect(results['a'], ['1', '2']);
         });
       });
     });
@@ -483,6 +502,12 @@ void main() {
         var results = parser.parse(['--verbose', 'chatty']);
         expect(results['verbose'], equals('chatty'));
         expect(results['Verbose'], equals('no'));
+      });
+
+      test('can be set by alias', () {
+        var parser = ArgParser()..addOption('a', aliases: ['b']);
+        var results = parser.parse(['--b=1']);
+        expect(results['a'], '1');
       });
     });
 


### PR DESCRIPTION
Closes https://github.com/dart-lang/args/issues/181

Add `aliases` named argument to `addFlag`, `addOption`, and `addMultiOption`, as well as a public `findByNameOrAlias` method on `ArgParser`. This allows you to provide aliases for an argument name, which eases the transition from one argument name to another.

Keys are _not_ added to the `options` map for each alias.

cc @Hixie