### PR TITLE
Enable lint prefer_typing_uninitialized_variables

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,7 @@ linter:
     - package_prefixed_library_names
     - prefer_final_fields
     - prefer_generic_function_type_aliases
+    - prefer_typing_uninitialized_variables
     - test_types_in_equals
     - throw_in_finally
     - unnecessary_brace_in_string_interps

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -119,7 +119,7 @@ class _Usage {
       option.abbr == null ? '' : '-${option.abbr}, ';
 
   String _longOption(Option option) {
-    var result;
+    String result;
     if (option.negatable!) {
       result = '--[no-]${option.name}';
     } else {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -41,7 +41,7 @@ String wrapText(String text, {int? length, int? hangingIndent}) {
     var trimmedText = line.trimLeft();
     final leadingWhitespace =
         line.substring(0, line.length - trimmedText.length);
-    var notIndented;
+    List<String> notIndented;
     if (hangingIndent != 0) {
       // When we have a hanging indent, we want to wrap the first line at one
       // width, and the rest at another (offset by hangingIndent), so we wrap
@@ -115,7 +115,7 @@ List<String> wrapTextAsLines(String text, {int start = 0, int? length}) {
     }
 
     var currentLineStart = 0;
-    var lastWhitespace;
+    int? lastWhitespace;
     for (var i = 0; i < line.length; ++i) {
       if (isWhitespace(line, i)) lastWhitespace = i;
 

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -19,7 +19,7 @@ Available commands:
 Run "test help <command>" for more information about a command.''';
 
 void main() {
-  late var runner;
+  late CommandRunner runner;
   setUp(() {
     runner = CommandRunner('test', 'A test command runner.');
   });

--- a/test/command_test.dart
+++ b/test/command_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
-  late var foo;
+  late FooCommand foo;
   setUp(() {
     foo = FooCommand();
 

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -122,7 +122,7 @@ void main() {
 
     group('callbacks', () {
       test('for present flags are invoked with the value', () {
-        var a;
+        bool? a;
         var parser = ArgParser();
         parser.addFlag('a', callback: (value) => a = value);
 
@@ -131,7 +131,7 @@ void main() {
       });
 
       test('for absent flags are invoked with the default value', () {
-        var a;
+        bool? a;
         var parser = ArgParser();
         parser.addFlag('a', defaultsTo: false, callback: (value) => a = value);
 
@@ -149,7 +149,7 @@ void main() {
       });
 
       test('for present options are invoked with the value', () {
-        var a;
+        String? a;
         var parser = ArgParser();
         parser.addOption('a', callback: (value) => a = value);
 
@@ -178,7 +178,7 @@ void main() {
       group('with addMultiOption', () {
         test('for multiple present, options are invoked with value as a list',
             () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a', callback: (value) => a = value);
 
@@ -193,7 +193,7 @@ void main() {
         test(
             'for single present, options are invoked with value as a single '
             'element list', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a', callback: (value) => a = value);
 
@@ -202,7 +202,7 @@ void main() {
         });
 
         test('for absent, options are invoked with default value', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a',
               defaultsTo: ['v', 'w'], callback: (value) => a = value);
@@ -212,7 +212,7 @@ void main() {
         });
 
         test('for absent, options are invoked with value as an empty list', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a', callback: (value) => a = value);
 
@@ -221,7 +221,7 @@ void main() {
         });
 
         test('parses comma-separated strings', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a', callback: (value) => a = value);
 
@@ -231,7 +231,7 @@ void main() {
 
         test("doesn't parse comma-separated strings with splitCommas: false",
             () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a',
               splitCommas: false, callback: (value) => a = value);
@@ -241,7 +241,7 @@ void main() {
         });
 
         test('parses empty strings', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a', callback: (value) => a = value);
 
@@ -250,7 +250,7 @@ void main() {
         });
 
         test('with allowed parses comma-separated strings', () {
-          var a;
+          List<String>? a;
           var parser = ArgParser();
           parser.addMultiOption('a',
               allowed: ['v', 'w', 'x'], callback: (value) => a = value);

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -12,7 +12,7 @@ void main() {
   });
 
   group('when trailing options are allowed', () {
-    late var parser;
+    late ArgParser parser;
     setUp(() {
       parser = ArgParser(allowTrailingOptions: true);
     });


### PR DESCRIPTION
Gives some safety against mistakes since there are fewer calls on a
statically dynamic variable.