### PR TITLE
Fix bug with mandatory flag

### DIFF
--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -36,6 +36,7 @@ class AllowAnythingParser implements ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
+      bool ignoreMandatory = false,
       List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addFlag() isn't supported.");

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -290,10 +290,6 @@ class ArgParser {
     var allNames = [name, ...aliases];
 
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
-      // ignore duplicate help (needed to not break current lib or `test_core`)
-      if (name == 'help') {
-        return;
-      }
       throw ArgumentError('Duplicate option or alias "$name".');
     }
 

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -119,9 +119,9 @@ class ArgParser {
   /// values from the [ArgResults].
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
-  /// 
+  ///
   /// If [ignoreMandatory] is `true`, then passing any explicit value for this flag will cause
-  /// all other mandatory options to not be mandatory. 
+  /// all other mandatory options to not be mandatory.
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
   /// aliases will not appear as keys in the [options] map.

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -76,6 +76,7 @@ class ArgParser {
         _commands = commands,
         commands = UnmodifiableMapView(commands),
         allowTrailingOptions = allowTrailingOptions {
+          // register by default a help flag
           addFlag('help', abbr: 'h', negatable: false, help: 'Print this usage information.');
         }
 
@@ -293,7 +294,7 @@ class ArgParser {
 
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
 
-      // ignore duplicate help (needed to not break current lib, `test_core`)
+      // ignore duplicate help (needed to not break current lib or `test_core`)
       if(name == 'help') {
         return;
       }

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -75,7 +75,9 @@ class ArgParser {
         options = UnmodifiableMapView(options),
         _commands = commands,
         commands = UnmodifiableMapView(commands),
-        allowTrailingOptions = allowTrailingOptions;
+        allowTrailingOptions = allowTrailingOptions {
+          addFlag('help', abbr: 'h', negatable: false, help: 'Print this usage information.');
+        }
 
   /// Defines a command.
   ///
@@ -288,7 +290,13 @@ class ArgParser {
       bool hide = false,
       List<String> aliases = const []}) {
     var allNames = [name, ...aliases];
+
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
+
+      // ignore duplicate help (needed to not break current lib, `test_core`)
+      if(name == 'help') {
+        return;
+      }
       throw ArgumentError('Duplicate option or alias "$name".');
     }
 

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -134,6 +134,7 @@ class ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
+      bool ignoreMandatory = false,
       List<String> aliases = const []}) {
     _addOption(
         name,
@@ -147,6 +148,7 @@ class ArgParser {
         OptionType.flag,
         negatable: negatable,
         hide: hide,
+        ignoreMandatory: ignoreMandatory,
         aliases: aliases);
   }
 
@@ -286,6 +288,7 @@ class ArgParser {
       bool? splitCommas,
       bool mandatory = false,
       bool hide = false,
+      bool ignoreMandatory = false,
       List<String> aliases = const []}) {
     var allNames = [name, ...aliases];
 
@@ -314,6 +317,7 @@ class ArgParser {
         splitCommas: splitCommas,
         mandatory: mandatory,
         hide: hide,
+        ignoreMandatory: ignoreMandatory,
         aliases: aliases);
     _options[name] = option;
     _optionsAndSeparators.add(option);

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -185,6 +185,8 @@ class ArgParser {
   /// Note that this makes argument parsing order-dependent in ways that are
   /// often surprising, and its use is discouraged in favor of reading values
   /// from the [ArgResults].
+  /// 
+  /// If [mandatory] is `true`, this option must be provided for correct usage.
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -290,9 +290,8 @@ class ArgParser {
     var allNames = [name, ...aliases];
 
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
-
       // ignore duplicate help (needed to not break current lib or `test_core`)
-      if(name == 'help') {
+      if (name == 'help') {
         return;
       }
       throw ArgumentError('Duplicate option or alias "$name".');

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -75,10 +75,7 @@ class ArgParser {
         options = UnmodifiableMapView(options),
         _commands = commands,
         commands = UnmodifiableMapView(commands),
-        allowTrailingOptions = allowTrailingOptions {
-          // register by default a help flag
-          addFlag('help', abbr: 'h', negatable: false, help: 'Print this usage information.');
-        }
+        allowTrailingOptions = allowTrailingOptions;
 
   /// Defines a command.
   ///

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -310,6 +310,12 @@ class ArgParser {
       }
     }
 
+    // Make sure the option is not ignoring mandatory with a default value of true.
+    if (ignoreMandatory && defaultsTo != null && defaultsTo == true) {
+      throw ArgumentError(
+          'The option $name cannot ignore mandatory and have a default value of true.');
+    }
+
     // Make sure the option is not mandatory with a default value.
     if (mandatory && defaultsTo != null) {
       throw ArgumentError(

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -185,7 +185,7 @@ class ArgParser {
   /// Note that this makes argument parsing order-dependent in ways that are
   /// often surprising, and its use is discouraged in favor of reading values
   /// from the [ArgResults].
-  /// 
+  ///
   /// If [mandatory] is `true`, this option must be provided for correct usage.
   ///
   /// If [hide] is `true`, this option won't be included in [usage].

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -119,6 +119,9 @@ class ArgParser {
   /// values from the [ArgResults].
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
+  /// 
+  /// If [ignoreMandatory] is `true`, then passing any explicit value for this flag will cause
+  /// all other mandatory options to not be mandatory. 
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
   /// aliases will not appear as keys in the [options] map.

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -20,6 +20,7 @@ Option newOption(
     bool? splitCommas,
     bool mandatory = false,
     bool hide = false,
+    bool ignoreMandatory = false,
     List<String> aliases = const []}) {
   return Option._(name, abbr, help, valueHelp, allowed, allowedHelp, defaultsTo,
       callback, type,
@@ -27,6 +28,7 @@ Option newOption(
       splitCommas: splitCommas,
       mandatory: mandatory,
       hide: hide,
+      ignoreMandatory: ignoreMandatory,
       aliases: aliases);
 }
 
@@ -82,6 +84,9 @@ class Option {
   /// Whether this option should be hidden from usage documentation.
   final bool hide;
 
+  /// Whether this option should ignore the mandatory check (used for flags like : version or help).
+  final bool ignoreMandatory;
+
   /// All aliases for [name].
   final List<String> aliases;
 
@@ -108,6 +113,7 @@ class Option {
       bool? splitCommas,
       this.mandatory = false,
       this.hide = false,
+      this.ignoreMandatory = false,
       this.aliases = const []})
       : allowed = allowed == null ? null : List.unmodifiable(allowed),
         allowedHelp =

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -92,12 +92,8 @@ class Parser {
       _rest.add(_args.removeFirst());
     }
 
-    // if we have the help flag enabled
-    // we show the usage message and exit
-    if (_results.containsKey('help')) {
-      print(_grammar.usage);
-      exit(0);
-    }
+    // if we have the help flag enabled we ignore the next mandatory flags
+    final ignoreMandatory = _results.containsKey('help');
 
     // Check if mandatory and invoke existing callbacks.
     _grammar.options.forEach((name, option) {
@@ -105,7 +101,7 @@ class Parser {
 
       // Check if an option was mandatory and exist
       // if not throw an exception
-      if (option.mandatory && parsedOption == null) {
+      if (!ignoreMandatory && option.mandatory && parsedOption == null) {
         throw ArgParserException('Option $name is mandatory.', [name]);
       }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -95,7 +95,7 @@ class Parser {
     // the mandatory check
     var ignoreMandatory = false;
 
-    for(final name in _results.keys) {
+    for (final name in _results.keys) {
       final option = _grammar.options[name];
       if (option != null && option.ignoreMandatory) {
         ignoreMandatory = true;

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -105,11 +105,7 @@ class Parser {
         // make sure the flag value is true
         // checking all the possible types
         if (value != null) {
-          if (value is String) {
-            flagVal = value.toLowerCase() == 'true';
-          } else if (value is int || value is double) {
-            flagVal = value >= 1;
-          } else if (value is bool) {
+          if (value is bool) {
             flagVal = value;
           }
         }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -94,7 +94,7 @@ class Parser {
 
     // if we have the help flag enabled
     // we show the usage message and exit
-    if(_results.containsKey('help')) {
+    if (_results.containsKey('help')) {
       print(_grammar.usage);
       exit(0);
     }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -100,18 +100,16 @@ class Parser {
       final value = entry.value;
       final option = _grammar.options[name];
       // only checking if the option is a flag
-      if (option != null && option.isFlag ) {
+      if (option != null && option.isFlag) {
         var flagVal = true;
         // make sure the flag value is true
         // checking all the possible types
         if (value != null) {
           if (value is String) {
             flagVal = value.toLowerCase() == 'true';
-          }
-          else if (value is int || value is double) {
+          } else if (value is int || value is double) {
             flagVal = value >= 1;
-          }
-          else if (value is bool) {
+          } else if (value is bool) {
             flagVal = value;
           }
         }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:collection';
+import 'dart:io';
 
 import 'arg_parser.dart';
 import 'arg_parser_exception.dart';
@@ -89,6 +90,13 @@ class Parser {
       // the [allowTrailingOptions] option is set.
       if (!_grammar.allowTrailingOptions) break;
       _rest.add(_args.removeFirst());
+    }
+
+    // if we have the help flag enabled
+    // we show the usage message and exit
+    if(_results.containsKey('help')) {
+      print(_grammar.usage);
+      exit(0);
     }
 
     // Check if mandatory and invoke existing callbacks.

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -91,8 +91,17 @@ class Parser {
       _rest.add(_args.removeFirst());
     }
 
-    // if we have the help flag enabled we ignore the next mandatory flags
-    final ignoreMandatory = _results.containsKey('help');
+    // Check if there are any parsed flags that ignore
+    // the mandatory check
+    var ignoreMandatory = false;
+
+    for(final name in _results.keys) {
+      final option = _grammar.options[name];
+      if (option != null && option.ignoreMandatory) {
+        ignoreMandatory = true;
+        break;
+      }
+    }
 
     // Check if mandatory and invoke existing callbacks.
     _grammar.options.forEach((name, option) {
@@ -100,6 +109,8 @@ class Parser {
 
       // Check if an option was mandatory and exist
       // if not throw an exception
+      // if there is a flag which ignore mandatory
+      // we are ignoring this check
       if (!ignoreMandatory && option.mandatory && parsedOption == null) {
         throw ArgParserException('Option $name is mandatory.', [name]);
       }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -95,11 +95,30 @@ class Parser {
     // the mandatory check
     var ignoreMandatory = false;
 
-    for (final name in _results.keys) {
+    for (final entry in _results.entries) {
+      final name = entry.key;
+      final value = entry.value;
       final option = _grammar.options[name];
-      if (option != null && option.ignoreMandatory) {
-        ignoreMandatory = true;
-        break;
+      // only checking if the option is a flag
+      if (option != null && option.isFlag ) {
+        var flagVal = true;
+        // make sure the flag value is true
+        // checking all the possible types
+        if (value != null) {
+          if (value is String) {
+            flagVal = value.toLowerCase() == 'true';
+          }
+          else if (value is int || value is double) {
+            flagVal = value >= 1;
+          }
+          else if (value is bool) {
+            flagVal = value;
+          }
+        }
+        if (option.ignoreMandatory && flagVal) {
+          ignoreMandatory = true;
+          break;
+        }
       }
     }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:collection';
-import 'dart:io';
 
 import 'arg_parser.dart';
 import 'arg_parser_exception.dart';

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -531,6 +531,23 @@ void main() {
           expect(results['test'], equals('test'));
         });
       });
+
+      group('ignore mandatory', () {
+        test('throw if is false', () {
+          var parser = ArgParser();
+          parser.addFlag('help', ignoreMandatory: false);
+          parser.addOption('test', mandatory: true);
+          throwsFormat(parser, []);
+        });
+
+        test('not throw if is true', () {
+          var parser = ArgParser();
+          parser.addFlag('help', ignoreMandatory: true);
+          parser.addOption('test', mandatory: true);
+          var results = parser.parse(['--help']);
+          expect(results['help'], isNotNull);
+        });
+      });
     });
 
     group('remaining args', () {

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -533,14 +533,14 @@ void main() {
       });
 
       group('ignore mandatory', () {
-        test('throw if is false', () {
+        test('throw if false', () {
           var parser = ArgParser();
           parser.addFlag('help', ignoreMandatory: false);
           parser.addOption('test', mandatory: true);
           throwsFormat(parser, []);
         });
 
-        test('not throw if is true', () {
+        test('no throw if true', () {
           var parser = ArgParser();
           parser.addFlag('help', ignoreMandatory: true);
           parser.addOption('test', mandatory: true);

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -551,8 +551,8 @@ void main() {
         test('throw if ignoring with default value of true', () {
           var parser = ArgParser();
           throwsIllegalArg(() => {
-            parser.addFlag('help', ignoreMandatory: true, defaultsTo: true)
-          });
+                parser.addFlag('help', ignoreMandatory: true, defaultsTo: true)
+              });
         });
       });
     });

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -547,6 +547,13 @@ void main() {
           var results = parser.parse(['--help']);
           expect(results['help'], isNotNull);
         });
+
+        test('throw if ignoring with default value of true', () {
+          var parser = ArgParser();
+          throwsIllegalArg(() => {
+            parser.addFlag('help', ignoreMandatory: true, defaultsTo: true)
+          });
+        });
       });
     });
 


### PR DESCRIPTION
As mentioned in #194 there is a bug when you use the mandatory flag in an option with an help flag (to display the usage message). 

Example (from [here](https://stackoverflow.com/questions/67384823/how-to-use-mandatory-field-in-dart-args-package)):

```dart
final parser = ArgParser()
    ..addOption('name', abbr: 'n', help: 'Provide your name', mandatory: true)
    ..addFlag('help', abbr: 'h', help: 'Provide usage instruction', negatable: false);
final results = parser.parse(['--help']);
```
Result:
```
Unhandled exception:
FormatException: Option name is mandatory.
```
Instead we should see the usage message of the parser and then exit.

This pull request added a way to detect if there is a help flag and when used it will ignore the mandatory flags.
We can then use the parse results to check if an help flag has been parsed and display the help message.

```dart
if (results.wasParsed('help')){
  print(parser.usage);
  exit(0);
}
```

I think this is more a hotfix than a correct work around of the issue.

The first thing I tried to do was to print and then exit the `Parser`. But this is breaking quite a lot of tests...
Then I tried to remove the exit function and fix the problems I got with the `CommandRunner`.
I noticed that `CommandRunner` had a similar feature. When a help flag is detected it will display the usage message.
I was trying to do the same thing inside `ArgParser` but he is used inside `CommandRunner` and this is breaking some tests too.
To fix them I should know, inside the `ArgParser`, that we are used by a `CommandRunner` but I don't think this is a clean solution.

Maybe creating a `ProgramRunner` or `ArgsRunner` using the `ArgParser` to do like in the `CommandRunner` but with no commands and just simple args. 

If you have any advice on how to implement this kind of behavior, I would be pleased.