### PR TITLE
Add ability to group commands by category in usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Add the ability to group commands by category in usage text.
+
 ## 2.2.0
 
 * Suggest similar commands if an unknown command is encountered, when using the

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -436,6 +436,7 @@ String _getCommandUsage(Map<String, Command> commands,
   for (var category in categories) {
     if (category != '') {
       buffer.writeln();
+      buffer.writeln();
       buffer.write('$category');
     }
     for (var command in commandsByCategory[category]!) {
@@ -449,9 +450,6 @@ String _getCommandUsage(Map<String, Command> commands,
         buffer.write(' ' * columnStart);
         buffer.write(line);
       }
-    }
-    if (category != '' && category != categories.last) {
-      buffer.writeln();
     }
   }
 

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -422,17 +422,12 @@ String _getCommandUsage(Map<String, Command> commands,
   names = names.toList()..sort();
 
   // Group the commands by category.
-  var commandsByCategory = <String, List<Command>?>{};
+  var commandsByCategory = SplayTreeMap<String, List<Command>>();
   for (var name in names) {
     var category = commands[name]!.category;
-    if (commandsByCategory[category] == null) {
-      commandsByCategory[category] = [];
-    }
-    commandsByCategory[category]!.add(commands[name]!);
+    commandsByCategory.putIfAbsent(category, () => []).add(commands[name]!);
   }
-  // Sort categories alphabetically.
   final categories = commandsByCategory.keys.toList();
-  categories.sort();
 
   var length = names.map((name) => name.length).reduce(math.max);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -53,6 +53,30 @@ Available commands:
 Run "test help <command>" for more information about a command.'''));
     });
 
+    test('displays categories', () {
+      runner.addCommand(Category1Command());
+      runner.addCommand(Category2Command());
+      runner.addCommand(FooCommand());
+
+      expect(runner.usage, equals('''
+A test command runner.
+
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+  foo   Set a value.
+Displayers
+  baz   Display a value.
+
+Printers
+  bar   Print a value.
+
+Run "test help <command>" for more information about a command.'''));
+    });
+
     test('truncates newlines in command descriptions by default', () {
       runner.addCommand(MultilineCommand());
 

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -69,8 +69,29 @@ Global options:
 
 Available commands:
   foo   Set a value.
+
 Displayers
   baz   Display a value.
+
+Printers
+  bar   Print a value.
+
+Run "test help <command>" for more information about a command.'''));
+      });
+
+      test('except when all commands in a category are hidden', () {
+        runner.addCommand(Category1Command());
+        runner.addCommand(HiddenCategorizedCommand());
+
+        expect(runner.usage, equals('''
+A test command runner.
+
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
 
 Printers
   bar   Print a value.
@@ -91,6 +112,7 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
+
 Displayers
   baz   Display a value.
 
@@ -114,6 +136,7 @@ Global options:
 -h, --help    Print this usage information.
 
 Available commands:
+
 Displayers
   baz    Display a value.
   baz2   Display another value.
@@ -181,6 +204,7 @@ Run "test help <command>" for more information about a command.'''));
     test("doesn't print hidden commands", () {
       runner
         ..addCommand(HiddenCommand())
+        ..addCommand(HiddenCategorizedCommand())
         ..addCommand(FooCommand());
 
       expect(runner.usage, equals('''

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -53,12 +53,13 @@ Available commands:
 Run "test help <command>" for more information about a command.'''));
     });
 
-    test('displays categories', () {
-      runner.addCommand(Category1Command());
-      runner.addCommand(Category2Command());
-      runner.addCommand(FooCommand());
+    group('displays categories', () {
+      test('when some commands are categorized', () {
+        runner.addCommand(Category1Command());
+        runner.addCommand(Category2Command());
+        runner.addCommand(FooCommand());
 
-      expect(runner.usage, equals('''
+        expect(runner.usage, equals('''
 A test command runner.
 
 Usage: test <command> [arguments]
@@ -75,6 +76,53 @@ Printers
   bar   Print a value.
 
 Run "test help <command>" for more information about a command.'''));
+      });
+
+      test('when all commands are categorized', () {
+        runner.addCommand(Category1Command());
+        runner.addCommand(Category2Command());
+
+        expect(runner.usage, equals('''
+A test command runner.
+
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+Displayers
+  baz   Display a value.
+
+Printers
+  bar   Print a value.
+
+Run "test help <command>" for more information about a command.'''));
+      });
+
+      test('when multiple commands are in a category', () {
+        runner.addCommand(Category1Command());
+        runner.addCommand(Category2Command());
+        runner.addCommand(Category2Command2());
+
+        expect(runner.usage, equals('''
+A test command runner.
+
+Usage: test <command> [arguments]
+
+Global options:
+-h, --help    Print this usage information.
+
+Available commands:
+Displayers
+  baz    Display a value.
+  baz2   Display another value.
+
+Printers
+  bar    Print a value.
+
+Run "test help <command>" for more information about a command.'''));
+      });
     });
 
     test('truncates newlines in command descriptions by default', () {
@@ -131,7 +179,9 @@ Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
-      runner..addCommand(HiddenCommand())..addCommand(FooCommand());
+      runner
+        ..addCommand(HiddenCommand())
+        ..addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -117,6 +117,27 @@ class Category2Command extends Command {
   }
 }
 
+class Category2Command2 extends Command {
+  var hasRun = false;
+
+  @override
+  final name = 'baz2';
+
+  @override
+  final description = 'Display another value.';
+
+  @override
+  final category = 'Displayers';
+
+  @override
+  final takesArguments = false;
+
+  @override
+  void run() {
+    hasRun = true;
+  }
+}
+
 class MultilineCommand extends Command {
   var hasRun = false;
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -75,6 +75,48 @@ class AsyncValueCommand extends Command<String> {
   Future<String> run() async => 'hi';
 }
 
+class Category1Command extends Command {
+  var hasRun = false;
+
+  @override
+  final name = 'bar';
+
+  @override
+  final description = 'Print a value.';
+
+  @override
+  final category = 'Printers';
+
+  @override
+  final takesArguments = false;
+
+  @override
+  void run() {
+    hasRun = true;
+  }
+}
+
+class Category2Command extends Command {
+  var hasRun = false;
+
+  @override
+  final name = 'baz';
+
+  @override
+  final description = 'Display a value.';
+
+  @override
+  final category = 'Displayers';
+
+  @override
+  final takesArguments = false;
+
+  @override
+  void run() {
+    hasRun = true;
+  }
+}
+
 class MultilineCommand extends Command {
   var hasRun = false;
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -231,6 +231,30 @@ class HiddenCommand extends Command {
   }
 }
 
+class HiddenCategorizedCommand extends Command {
+  var hasRun = false;
+
+  @override
+  final name = 'hiddencategorized';
+
+  @override
+  final description = 'Set a value.';
+
+  @override
+  final category = 'Some category';
+
+  @override
+  final hidden = true;
+
+  @override
+  final takesArguments = false;
+
+  @override
+  void run() {
+    hasRun = true;
+  }
+}
+
 class AliasedCommand extends Command {
   var hasRun = false;
 


### PR DESCRIPTION
To enable https://github.com/flutter/flutter/issues/83706

Formatting is loosely based on what `Brew` does, and open to suggestions.  Existing tests are unchanged.

Example (all displayed commands categorized):
<img width="669" alt="Screenshot 2021-07-23 at 16 22 40" src="https://user-images.githubusercontent.com/6655696/126796093-e8652385-c3d7-4600-83b1-76852ab46ea4.png">
