### PR TITLE
show similar commands with an edit distance of 2 or less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0
+
+* Suggest similar commands if an unknown command is encountered, when using the
+  `CommandRunner`.
+  * The max edit distance for suggestions defaults to 2, but can be configured
+    using the `suggestionDistanceLimit` parameter on the constructor. You can
+    set it to `0` to disable the feature.
+
 ## 2.1.1
 
 * Fix a bug with `mandatory` options which caused a null assertion failure when

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -473,8 +473,8 @@ String _getCommandUsage(Map<String, Command> commands,
 /// See https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance
 int _editDistance(String from, String to) {
   // Pad words with a space in front to mimic indexing by 1 instead of 0.
-  from = from.padLeft(1);
-  to = to.padLeft(1);
+  from = ' $from';
+  to = ' $to';
   var distances = [
     for (var i = 0; i < from.length; i++)
       [

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -472,7 +472,7 @@ String _getCommandUsage(Map<String, Command> commands,
 ///
 /// See https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance
 int _editDistance(String from, String to) {
-  // Pad words with a space in front to mimic indexing by 1 instead of 0.
+  // Add a space in front to mimic indexing by 1 instead of 0.
   from = ' $from';
   to = ' $to';
   var distances = [

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -160,6 +160,7 @@ class CommandRunner<T> {
       final candidates =
           SplayTreeSet<Command<T>>((a, b) => distances[a]! - distances[b]!);
       for (var command in commands.values) {
+        if (command.hidden) continue;
         var distance = _editDistance(name, command.name);
         if (distance <= suggestedCommandsMaxEditDistance) {
           distances[command] = distance;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.1.1
+version: 2.2.0
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -246,7 +246,9 @@ information about a command.'''));
 
         for (var typo in ['afoo', 'foao', 'fooa']) {
           expect(() => runner.run([typo]), throwsUsageException('''
-Could not find a command named "$typo". The most similar command is:
+Could not find a command named "$typo".
+
+Did you mean one of these?
   foo
 ''', anything));
         }
@@ -258,7 +260,9 @@ Could not find a command named "$typo". The most similar command is:
 
         for (var typo in ['ong', 'lng', 'lon']) {
           expect(() => runner.run([typo]), throwsUsageException('''
-Could not find a command named "$typo". The most similar command is:
+Could not find a command named "$typo".
+
+Did you mean one of these?
   long
 ''', anything));
         }
@@ -270,7 +274,9 @@ Could not find a command named "$typo". The most similar command is:
 
         for (var typo in ['aong', 'lang', 'lona']) {
           expect(() => runner.run([typo]), throwsUsageException('''
-Could not find a command named "$typo". The most similar command is:
+Could not find a command named "$typo".
+
+Did you mean one of these?
   long
 ''', anything));
         }
@@ -282,7 +288,9 @@ Could not find a command named "$typo". The most similar command is:
 
         for (var typo in ['olng', 'lnog', 'logn']) {
           expect(() => runner.run([typo]), throwsUsageException('''
-Could not find a command named "$typo". The most similar command is:
+Could not find a command named "$typo".
+
+Did you mean one of these?
   long
 ''', anything));
         }
@@ -294,7 +302,9 @@ Could not find a command named "$typo". The most similar command is:
 
         for (var typo in ['oln', 'on', 'lgn', 'alogn']) {
           expect(() => runner.run([typo]), throwsUsageException('''
-Could not find a command named "$typo". The most similar command is:
+Could not find a command named "$typo".
+
+Did you mean one of these?
   long
 ''', anything));
         }
@@ -307,13 +317,17 @@ Could not find a command named "$typo". The most similar command is:
         runner.addCommand(b);
 
         expect(() => runner.run(['abdc']), throwsUsageException('''
-Could not find a command named "abdc". The most similar commands are:
+Could not find a command named "abdc".
+
+Did you mean one of these?
   abcd
   bcd
 ''', anything));
 
         expect(() => runner.run(['bdc']), throwsUsageException('''
-Could not find a command named "bdc". The most similar commands are:
+Could not find a command named "bdc".
+
+Did you mean one of these?
   bcd
   abcd
 ''', anything));
@@ -333,7 +347,7 @@ Could not find a command named "bdc". The most similar commands are:
 
       test('max edit distance is configurable', () {
         runner = CommandRunner('test', 'A test command runner.',
-            suggestedCommandsMaxEditDistance: 1)
+            suggestionDistanceLimit: 1)
           ..addCommand(LongCommand());
         expect(
             () => runner.run(['ng']),
@@ -341,10 +355,12 @@ Could not find a command named "bdc". The most similar commands are:
                 'Could not find a command named "ng".', anything));
 
         runner = CommandRunner('test', 'A test command runner.',
-            suggestedCommandsMaxEditDistance: 3)
+            suggestionDistanceLimit: 3)
           ..addCommand(LongCommand());
         expect(() => runner.run(['g']), throwsUsageException('''
-Could not find a command named "g". The most similar command is:
+Could not find a command named "g".
+
+Did you mean one of these?
   long
 ''', anything));
       });
@@ -354,7 +370,9 @@ Could not find a command named "g". The most similar command is:
         command.addSubcommand(LongCommand());
         runner.addCommand(command);
         expect(() => runner.run(['foo', 'ong']), throwsUsageException('''
-Could not find a subcommand named "ong" for "test foo". The most similar command is:
+Could not find a subcommand named "ong" for "test foo".
+
+Did you mean one of these?
   long
 ''', anything));
       });

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -107,9 +107,7 @@ Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
-      runner
-        ..addCommand(HiddenCommand())
-        ..addCommand(FooCommand());
+      runner..addCommand(HiddenCommand())..addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.
@@ -329,6 +327,34 @@ Could not find a command named "bdc". The most similar commands are:
               throwsUsageException(
                   'Could not find a command named "$typo".', anything));
         }
+      });
+
+      test('max edit distance is configurable', () {
+        runner = CommandRunner('test', 'A test command runner.',
+            suggestedCommandsMaxEditDistance: 1)
+          ..addCommand(LongCommand());
+        expect(
+            () => runner.run(['ng']),
+            throwsUsageException(
+                'Could not find a command named "ng".', anything));
+
+        runner = CommandRunner('test', 'A test command runner.',
+            suggestedCommandsMaxEditDistance: 3)
+          ..addCommand(LongCommand());
+        expect(() => runner.run(['g']), throwsUsageException('''
+Could not find a command named "g". The most similar command is:
+  long
+''', anything));
+      });
+
+      test('supports subcommands', () {
+        var command = FooCommand();
+        command.addSubcommand(LongCommand());
+        runner.addCommand(command);
+        expect(() => runner.run(['foo', 'ong']), throwsUsageException('''
+Could not find a subcommand named "ong" for "test foo". The most similar command is:
+  long
+''', anything));
       });
     });
 

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -237,6 +237,99 @@ information about a command.'''));
           completes);
     });
 
+    group('suggests similar commands', () {
+      test('deletions', () {
+        var command = FooCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['afoo', 'foao', 'fooa']) {
+          expect(() => runner.run([typo]), throwsUsageException('''
+Could not find a command named "$typo". The most similar command is:
+  foo
+''', anything));
+        }
+      });
+
+      test('additions', () {
+        var command = LongCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['ong', 'lng', 'lon']) {
+          expect(() => runner.run([typo]), throwsUsageException('''
+Could not find a command named "$typo". The most similar command is:
+  long
+''', anything));
+        }
+      });
+
+      test('substitutions', () {
+        var command = LongCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['aong', 'lang', 'lona']) {
+          expect(() => runner.run([typo]), throwsUsageException('''
+Could not find a command named "$typo". The most similar command is:
+  long
+''', anything));
+        }
+      });
+
+      test('swaps', () {
+        var command = LongCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['olng', 'lnog', 'logn']) {
+          expect(() => runner.run([typo]), throwsUsageException('''
+Could not find a command named "$typo". The most similar command is:
+  long
+''', anything));
+        }
+      });
+
+      test('combinations', () {
+        var command = LongCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['oln', 'on', 'lgn', 'alogn']) {
+          expect(() => runner.run([typo]), throwsUsageException('''
+Could not find a command named "$typo". The most similar command is:
+  long
+''', anything));
+        }
+      });
+
+      test('sorts by relevance', () {
+        var a = CustomNameCommand('abcd');
+        runner.addCommand(a);
+        var b = CustomNameCommand('bcd');
+        runner.addCommand(b);
+
+        expect(() => runner.run(['abdc']), throwsUsageException('''
+Could not find a command named "abdc". The most similar commands are:
+  abcd
+  bcd
+''', anything));
+
+        expect(() => runner.run(['bdc']), throwsUsageException('''
+Could not find a command named "bdc". The most similar commands are:
+  bcd
+  abcd
+''', anything));
+      });
+
+      test('omits commands with an edit distance over 2', () {
+        var command = LongCommand();
+        runner.addCommand(command);
+
+        for (var typo in ['llllong', 'aolgn', 'abcg', 'longggg']) {
+          expect(
+              () => runner.run([typo]),
+              throwsUsageException(
+                  'Could not find a command named "$typo".', anything));
+        }
+      });
+    });
+
     group('with --help', () {
       test('with no command prints the usage', () {
         expect(() => runner.run(['--help']), prints('''

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -107,7 +107,9 @@ Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
-      runner..addCommand(HiddenCommand())..addCommand(FooCommand());
+      runner
+        ..addCommand(HiddenCommand())
+        ..addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -358,6 +358,15 @@ Could not find a subcommand named "ong" for "test foo". The most similar command
   long
 ''', anything));
       });
+
+      test('doesn\'t show hidden commands', () {
+        var command = HiddenCommand();
+        runner.addCommand(command);
+        expect(
+            () => runner.run(['hidde']),
+            throwsUsageException(
+                'Could not find a command named "hidde".', anything));
+      });
     });
 
     group('with --help', () {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -223,6 +223,16 @@ class AllowAnythingCommand extends Command {
   }
 }
 
+class CustomNameCommand extends Command {
+  @override
+  final String name;
+
+  CustomNameCommand(this.name);
+
+  @override
+  String get description => 'A command with a custom name';
+}
+
 void throwsIllegalArg(function, {String? reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }
@@ -231,7 +241,7 @@ void throwsFormat(ArgParser parser, List<String> args) {
   expect(() => parser.parse(args), throwsFormatException);
 }
 
-Matcher throwsUsageException(String message, String usage) =>
+Matcher throwsUsageException(Object? message, Object? usage) =>
     throwsA(isA<UsageException>()
         .having((e) => e.message, 'message', message)
         .having((e) => e.usage, 'usage', usage));


### PR DESCRIPTION
Fixes https://github.com/dart-lang/args/issues/201

Uses the [Optimal string alignment distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance) algorithm to compute edit distance, which allows for additions, removals, substitutions, and swaps - all as 1 cost operations.

Suggests any commands within an edit distance of <=2, ~although we should possibly make this configurable~ which is now configurable.

We should also consider whether this should be opt in - it is likely to break existing integration tests in some cases. ~We could also consider adding in an opt out mechanism.~ you can now opt out by setting the distance to zero.