### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 linter:
   rules:
     - avoid_null_checks_in_equality_operators

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -478,7 +478,7 @@ String _getCommandUsage(Map<String, Command> commands,
     if (category != '') {
       buffer.writeln();
       buffer.writeln();
-      buffer.write('$category');
+      buffer.write(category);
     }
     for (var command in commandsByCategory[category]!) {
       var lines = wrapTextAsLines(command.summary,

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -70,12 +70,11 @@ class ArgParser {
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
       this._aliases,
-      {bool allowTrailingOptions = true, this.usageLineLength})
+      {this.allowTrailingOptions = true, this.usageLineLength})
       : _options = options,
         options = UnmodifiableMapView(options),
         _commands = commands,
-        commands = UnmodifiableMapView(commands),
-        allowTrailingOptions = allowTrailingOptions;
+        commands = UnmodifiableMapView(commands);
 
   /// Defines a command.
   ///

--- a/lib/src/help_command.dart
+++ b/lib/src/help_command.dart
@@ -22,6 +22,8 @@ class HelpCommand<T> extends Command<T> {
   bool get hidden => true;
 
   @override
+  // TODO: Remove when https://github.com/dart-lang/linter/issues/2792 is fixed.
+  // ignore: prefer_void_to_null
   Null run() {
     // Show the default help if no command was specified.
     if (argResults!.rest.isEmpty) {

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -103,7 +103,7 @@ class Option {
       Map<String, String>? allowedHelp,
       this.defaultsTo,
       this.callback,
-      OptionType type,
+      this.type,
       {this.negatable,
       bool? splitCommas,
       this.mandatory = false,
@@ -112,7 +112,6 @@ class Option {
       : allowed = allowed == null ? null : List.unmodifiable(allowed),
         allowedHelp =
             allowedHelp == null ? null : Map.unmodifiable(allowedHelp),
-        type = type,
         // If the user doesn't specify [splitCommas], it defaults to true for
         // multiple options.
         splitCommas = splitCommas ?? type == OptionType.multiple {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.1.1
+version: 2.1.2-dev
 homepage: https://github.com/dart-lang/args
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
@@ -9,5 +9,5 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  pedantic: ^1.10.0
+  lints: ^1.0.0
   test: ^1.16.0

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -107,7 +107,9 @@ Run "test help <command>" for more information about a command.'''));
     });
 
     test("doesn't print hidden commands", () {
-      runner..addCommand(HiddenCommand())..addCommand(FooCommand());
+      runner
+        ..addCommand(HiddenCommand())
+        ..addCommand(FooCommand());
 
       expect(runner.usage, equals('''
 A test command runner.
@@ -315,7 +317,7 @@ Run "test help" to see global options.
         expect(
             runner.run(['--asdf']),
             throwsUsageException(
-                'Could not find an option named "asdf".', '$_defaultUsage'));
+                'Could not find an option named "asdf".', _defaultUsage));
       });
 
       test('for a command throws the command usage', () {

--- a/test/parse_performance_test.dart
+++ b/test/parse_performance_test.dart
@@ -43,8 +43,8 @@ void _testParserPerformance(ArgParser parser, String string) {
   var multiplier = 10;
   var largeList = List<String>.generate(baseSize * multiplier, (_) => string);
 
-  var baseAction = () => parser.parse(baseList);
-  var largeAction = () => parser.parse(largeList);
+  ArgResults baseAction() => parser.parse(baseList);
+  ArgResults largeAction() => parser.parse(largeList);
 
   // Warm up JIT.
   baseAction();


### PR DESCRIPTION
Fix existing violations of lints:
- `prefer_initializing_formals`
- `unnecessary_string_interpolations`
- `prefer_function_declarations_over_variables`

Ignore one case of `prefer_void_to_null` to work around
https://github.com/dart-lang/linter/issues/2792