### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Adding global arguments
 ```dart
 var runner = CommandRunner('dgit',  "A dart implementation of distributed version control.");
 // add global flag
-runner.addFlag('verbose', abbr: 'v', help: 'increase logging');
+runner.argParser.addFlag('verbose', abbr: 'v', help: 'increase logging');
 ```
 
 #### Command specific Arguments


### PR DESCRIPTION
In order to add a global argument to `CommandRunner`, you need to add it through its `argParser` (reference to #203)