### PR TITLE
prep to publish 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.3.1-dev
+## 2.3.1
+
+* Switch to using package:lints.
+* Address an issue with the readme API documentation (#211).
+* Populate the pubspec `repository` field.
 
 ## 2.3.0
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Dart CI](https://github.com/dart-lang/args/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/args/actions/workflows/test-package.yml)
+[![pub package](https://img.shields.io/pub/v/args.svg)](https://pub.dev/packages/args)
+[![package publisher](https://img.shields.io/pub/publisher/args.svg)](https://pub.dev/packages/args/publisher)
+
 Parses raw command-line arguments into a set of options and values.
 
 This library supports [GNU][] and [POSIX][] style options, and it works

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:lints/recommended.yaml
+
 linter:
   rules:
     - avoid_null_checks_in_equality_operators

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.3.1-dev
+version: 2.3.1
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.


### PR DESCRIPTION
prep to publish 2.3.1:
- rev tp 2.3.1
- update the changelog
- add markdown badges to the readme