### PR TITLE
Suggest command based on aliases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,5 +10,10 @@ on:
 
 jobs:
   publish:
+    # These permissions are required for authentication using OIDC and to enable
+    # us to create comments on PRs.
+    permissions:
+      id-token: write
+      pull-requests: write
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,5 @@ on:
 
 jobs:
   publish:
-    # These permissions are required for authentication using OIDC and to enable
-    # us to create comments on PRs.
-    permissions:
-      id-token: write
-      pull-requests: write
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0
+## 2.4.0-dev
 
 * Command suggestions will now also suggest based on aliases of a command.
 * Introduce getter `Command.suggestionAliases` for names that cannot be used as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0
+
+* Command suggestions will now also suggest based on aliases of a command.
+* Introduce getter `Command.suggestionAliases` for names that cannot be used as
+  aliases, but will trigger suggestions.
+
 ## 2.3.2
 
 * Require Dart 2.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0-dev
+## 2.4.0
 
 * Command suggestions will now also suggest based on aliases of a command.
 * Introduce getter `Command.suggestionAliases` for names that cannot be used as

--- a/lib/command_runner.dart
+++ b/lib/command_runner.dart
@@ -421,7 +421,7 @@ abstract class Command<T> {
 
   /// Alternate non-functional names for this command.
   ///
-  /// These names won't be used in the documentation, and also they will work
+  /// These names won't be used in the documentation, and also they won't work
   /// when invoked on the command line. But if an unknown command is used it
   /// will be matched against this when creating suggestions.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.4.0-dev
+version: 2.4.0
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.3.2
+version: 2.4.0
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.4.0
+version: 2.4.0-dev
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -481,6 +481,28 @@ Did you mean one of these?
             throwsUsageException(
                 'Could not find a command named "hidde".', anything));
       });
+
+      test('Suggests based on aliases', () {
+        var command = AliasedCommand();
+        runner.addCommand(command);
+        expect(() => runner.run(['rename']), throwsUsageException('''
+Could not find a command named "rename".
+
+Did you mean one of these?
+  aliased
+''', anything));
+      });
+
+      test('Suggests based on suggestedAliases', () {
+        var command = SuggestionAliasedCommand();
+        runner.addCommand(command);
+        expect(() => runner.run(['renamed']), throwsUsageException('''
+Could not find a command named "renamed".
+
+Did you mean one of these?
+  aliased
+''', anything));
+      });
     });
 
     group('with --help', () {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -266,7 +266,28 @@ class AliasedCommand extends Command {
   final takesArguments = false;
 
   @override
-  final aliases = const ['alias', 'als'];
+  final aliases = const ['alias', 'als', 'renamed'];
+
+  @override
+  void run() {
+    hasRun = true;
+  }
+}
+
+class SuggestionAliasedCommand extends Command {
+  bool hasRun = false;
+
+  @override
+  final name = 'aliased';
+
+  @override
+  final description = 'Set a value.';
+
+  @override
+  final takesArguments = false;
+
+  @override
+  final suggestionAliases = const ['renamed'];
 
   @override
   void run() {


### PR DESCRIPTION
Also introduce a concept of suggestionAliases (alternative names that cannot be used as a command name, but they will be used for suggesting the actual command).

The motivation comes from this suggestion: https://github.com/dart-lang/sdk/issues/50971#issuecomment-1412495274

That would allow us to give a good suggestion if someone writes `dart packages get` -> `Did you mean pub?`.

