### PR TITLE
update readme; add contributing doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.1-dev
+
+* Add a `CONTRIBUTING.md` file; move the publishing automation docs from the
+  readme into the contributing doc.
+
 ## 2.4.0
 
 * Command suggestions will now also suggest based on aliases of a command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement (CLA). You (or your employer) retain the copyright to your
+contribution; this simply gives us permission to use and redistribute your
+contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code Reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Coding style
+
+The Dart source code in this repo follows the:
+
+  * [Dart style guide](https://dart.dev/guides/language/effective-dart/style)
+
+You should familiarize yourself with those guidelines.
+
+## File headers
+
+All files in the Dart project must start with the following header; if you add a
+new file please also add this. The year should be a single number stating the
+year the file was created (don't use a range like "2011-2012"). Additionally, if
+you edit an existing file, you shouldn't update the year.
+
+    // Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
+
+## Publishing automation
+
+For information about our publishing automation and release process, see
+https://github.com/dart-lang/ecosystem/wiki/Publishing-automation.
+
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+We pledge to maintain an open and welcoming environment. For details, see our
+[code of conduct](https://dart.dev/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ print(results['mode']); // prints '[on, off]'
 
 This can be disabled by passing `splitCommas: false`.
 
-## Defining commands ##
+## Defining commands
 
 In addition to *options*, you can also define *commands*. A command is a named
 argument that has its own set of options. For example, consider this shell
@@ -295,7 +295,6 @@ e.g.
 File `dgit.dart`
 
 ```dart
-
 void main(List<String> args){
   var runner = CommandRunner("dgit", "A dart implementation of distributed version control.")
     ..addCommand(CommitCommand())
@@ -305,10 +304,7 @@ void main(List<String> args){
 
 When the above `run(args)` line executes it parses the command line args looking for one of the commands (`commit` or `stash`).
 
-
-
 If the [CommandRunner][] finds a matching command then the [CommandRunner][] calls the overridden `run()` method on the matching command (e.g. CommitCommand().run).
-
 
 Commands are defined by extending the [Command][] class. For example:
 
@@ -333,6 +329,7 @@ class CommitCommand extends Command {
   }
 }
 ```
+
 ### CommandRunner Arguments
 The [CommandRunner][] allows you to specify both global args as well as command specific arguments (and even sub-command specific arguments).
 
@@ -340,6 +337,7 @@ The [CommandRunner][] allows you to specify both global args as well as command 
 Add argments directly to the [CommandRunner] to specify global arguments:
 
 Adding global arguments
+
 ```dart
 var runner = CommandRunner('dgit',  "A dart implementation of distributed version control.");
 // add global flag
@@ -350,14 +348,13 @@ runner.argParser.addFlag('verbose', abbr: 'v', help: 'increase logging');
 Add arguments to each [Command][] to specify [Command][] specific arguments.
 
 ```dart
-
   CommitCommand() {
     // we can add command specific arguments here.
     // [argParser] is automatically created by the parent class.
     argParser.addFlag('all', abbr: 'a');
   }
-
 ```
+
 ### SubCommands
 
 Commands can also have subcommands, which are added with [addSubcommand][]. A
@@ -442,11 +439,6 @@ The resulting string looks something like this:
       [arm]       ARM Holding 32-bit chip
       [ia32]      Intel x86
 ```
-
-## Publishing automation
-
-For information about our publishing automation and release process, see
-https://github.com/dart-lang/ecosystem/wiki/Publishing-automation.
 
 [posix]: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html#tag_12_02
 [gnu]: https://www.gnu.org/prep/standards/standards.html#Command_002dLine-Interfaces

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.4.0
+version: 2.4.1-dev
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.


### PR DESCRIPTION
- update the readme to remove info about the publishing automation
- add a contributing doc (taken from `dart-lang/.github`; updated w/ publishing info
