### PR TITLE
adjust the validation of mandatory options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.2
+
+* Change the validation of `mandatory` options; they now perform validation when
+  the value is retreived (from the `ArgResults` object), instead of when the
+  args are parsed.
+
 ## 2.4.1
 
 * Add a `CONTRIBUTING.md` file; move the publishing automation docs from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.2
 
 * Change the validation of `mandatory` options; they now perform validation when
-  the value is retreived (from the `ArgResults` object), instead of when the
+  the value is retrieved (from the `ArgResults` object), instead of when the
   args are parsed.
 
 ## 2.4.1

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Parses raw command-line arguments into a set of options and values.
 
-This library supports [GNU][] and [POSIX][] style options, and it works
-in both server-side and client-side apps.
+This library supports [GNU][] and [POSIX][] style options, and it works in both
+server-side and client-side apps.
 
 ## Defining options
 
@@ -78,8 +78,8 @@ The callbacks for all options are called whenever a set of arguments is parsed.
 If an option isn't provided in the args, its callback is passed the default
 value, or `null` if no default value is set.
 
-If an option is `mandatory` but not provided, the parser throws an
-[`ArgParserException`][ArgParserException].
+If an option is `mandatory` but not provided, the results object throws an
+[`ArgumentError`][ArgumentError] on retrieval.
 
 ```dart
 parser.addOption('mode', mandatory: true);

--- a/lib/src/arg_results.dart
+++ b/lib/src/arg_results.dart
@@ -65,7 +65,12 @@ class ArgResults {
       throw ArgumentError('Could not find an option named "$name".');
     }
 
-    return _parser.options[name]!.valueOrDefault(_parsed[name]);
+    final option = _parser.options[name]!;
+    if (option.mandatory && !_parsed.containsKey(name)) {
+      throw ArgumentError('Option $name is mandatory.');
+    }
+
+    return option.valueOrDefault(_parsed[name]);
   }
 
   /// The names of the available options.

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -95,14 +95,15 @@ class Parser {
     _grammar.options.forEach((name, option) {
       var parsedOption = _results[name];
 
-      // Check if an option was mandatory and exist
-      // if not throw an exception
+      var callback = option.callback;
+      if (callback == null) return;
+
+      // Check if an option is mandatory and was passed; if not, throw an
+      // exception.
       if (option.mandatory && parsedOption == null) {
         throw ArgParserException('Option $name is mandatory.');
       }
 
-      var callback = option.callback;
-      if (callback == null) return;
       // ignore: avoid_dynamic_calls
       callback(option.valueOrDefault(parsedOption));
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.4.1
+version: 2.4.2
 description: >-
  Library for defining parsers for parsing raw command-line arguments into a set
  of options and values using GNU and POSIX style options.

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -736,7 +736,7 @@ Run "test help" to see global options.'''));
     runner.addCommand(subcommand);
     expect(
         () => runner.run([subcommand.name]),
-        throwsA(isA<UsageException>().having((e) => e.message, 'message',
+        throwsA(isA<ArgumentError>().having((e) => e.message, 'message',
             contains('Option mandatory-option is mandatory'))));
     expect(await runner.run([subcommand.name, '--mandatory-option', 'foo']),
         'foo');

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -514,14 +514,17 @@ void main() {
         test('throw if no args', () {
           var parser = ArgParser();
           parser.addOption('username', mandatory: true);
-          throwsFormat(parser, []);
+          var results = parser.parse([]);
+          expect(() => results['username'], throwsA(isA<ArgumentError>()));
         });
 
         test('throw if no mandatory args', () {
           var parser = ArgParser();
           parser.addOption('test');
           parser.addOption('username', mandatory: true);
-          throwsFormat(parser, ['--test', 'test']);
+          var results = parser.parse(['--test', 'test']);
+          expect(results['test'], equals('test'));
+          expect(() => results['username'], throwsA(isA<ArgumentError>()));
         });
 
         test('parse successfully', () {
@@ -529,6 +532,15 @@ void main() {
           parser.addOption('test', mandatory: true);
           var results = parser.parse(['--test', 'test']);
           expect(results['test'], equals('test'));
+        });
+
+        test('throws when value retrieved', () {
+          var parser = ArgParser();
+          parser.addFlag('help', abbr: 'h', negatable: false);
+          parser.addOption('test', mandatory: true);
+          var results = parser.parse(['-h']);
+          expect(results['help'], true);
+          expect(() => results['test'], throwsA(isA<ArgumentError>()));
         });
       });
     });


### PR DESCRIPTION
- change the validation of `mandatory` options; perform validation when the value is retrieved (from the `ArgResults` object), instead of when the args are parsed
- fix https://github.com/dart-lang/args/issues/245

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
