### PR TITLE
feat: show aliases in usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+* Show alias(es) in usage
+
 ## 2.4.2
 
 * Change the validation of `mandatory` options; they now perform validation when

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -21,6 +21,8 @@ class AllowAnythingParser implements ArgParser {
   bool get allowsAnything => true;
   @override
   int? get usageLineLength => null;
+  @override
+  bool get showAliasesInUsage => false;
 
   @override
   ArgParser addCommand(String name, [ArgParser? parser]) {

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -49,16 +49,26 @@ class ArgParser {
   /// arguments.
   bool get allowsAnything => false;
 
+  /// Whether or not this parser's [usage] will show option aliases
+  final bool showAliasesInUsage;
+
   /// Creates a new ArgParser.
   ///
   /// If [allowTrailingOptions] is `true` (the default), the parser will parse
   /// flags and options that appear after positional arguments. If it's `false`,
   /// the parser stops parsing as soon as it finds an argument that is neither
   /// an option nor a command.
-  factory ArgParser({bool allowTrailingOptions = true, int? usageLineLength}) =>
+  ///
+  /// If [showAliasesInUsage] is `true` (default is `false`), the parser's
+  /// usage will show option aliases
+  factory ArgParser(
+          {bool allowTrailingOptions = true,
+          int? usageLineLength,
+          bool showAliasesInUsage = false}) =>
       ArgParser._(<String, Option>{}, <String, ArgParser>{}, <String, String>{},
           allowTrailingOptions: allowTrailingOptions,
-          usageLineLength: usageLineLength);
+          usageLineLength: usageLineLength,
+          showAliasesInUsage: showAliasesInUsage);
 
   /// Creates a new ArgParser that treats *all input* as non-option arguments.
   ///
@@ -70,7 +80,9 @@ class ArgParser {
 
   ArgParser._(Map<String, Option> options, Map<String, ArgParser> commands,
       this._aliases,
-      {this.allowTrailingOptions = true, this.usageLineLength})
+      {this.allowTrailingOptions = true,
+      this.usageLineLength,
+      this.showAliasesInUsage = false})
       : _options = options,
         options = UnmodifiableMapView(options),
         _commands = commands,
@@ -337,7 +349,8 @@ class ArgParser {
   ///
   /// This is basically the help text shown on the command line.
   String get usage {
-    return generateUsage(_optionsAndSeparators, lineLength: usageLineLength);
+    return generateUsage(_optionsAndSeparators,
+        lineLength: usageLineLength, showAliases: showAliasesInUsage);
   }
 
   /// Returns the default value for [option].

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -22,8 +22,11 @@ import 'utils.dart';
 /// text is wrapped. Help that extends past this column will be wrapped at the
 /// nearest whitespace (or truncated if there is no available whitespace). If
 /// `null` there will not be any wrapping.
-String generateUsage(List optionsAndSeparators, {int? lineLength}) =>
-    _Usage(optionsAndSeparators, lineLength).generate();
+///
+/// [showAliases] specifies whether or not to show option aliases
+String generateUsage(List optionsAndSeparators,
+        {int? lineLength, bool showAliases = false}) =>
+    _Usage(optionsAndSeparators, lineLength, showAliases).generate();
 
 class _Usage {
   /// Abbreviation, long name, help.
@@ -58,7 +61,10 @@ class _Usage {
   /// whitespace (or truncated if there is no available whitespace).
   final int? lineLength;
 
-  _Usage(this._optionsAndSeparators, this.lineLength);
+  /// Whether or not to show option aliases
+  final bool showAliases;
+
+  _Usage(this._optionsAndSeparators, this.lineLength, this.showAliases);
 
   /// Generates a string displaying usage information for the defined options.
   /// This is basically the help text shown on the command line.
@@ -121,11 +127,13 @@ class _Usage {
 
   String _longOption(Option option) {
     final result = StringBuffer();
-    String separator() {
-      return result.isEmpty ? '' : ',';
-    }
+    String separator() => result.isEmpty ? '' : ',';
 
-    for (final name in [option.name, ...option.aliases]) {
+    final names = <String>[option.name];
+    if (showAliases) {
+      names.addAll(option.aliases);
+    }
+    for (final name in names) {
       if (option.negatable!) {
         result.write('${separator()}--[no-]$name');
       } else {

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -120,16 +120,22 @@ class _Usage {
       option.abbr == null ? '' : '-${option.abbr}, ';
 
   String _longOption(Option option) {
-    String result;
-    if (option.negatable!) {
-      result = '--[no-]${option.name}';
-    } else {
-      result = '--${option.name}';
+    final result = StringBuffer();
+    String separator() {
+      return result.isEmpty ? '' : ',';
     }
 
-    if (option.valueHelp != null) result += '=<${option.valueHelp}>';
+    for (final name in [option.name, ...option.aliases]) {
+      if (option.negatable!) {
+        result.write('${separator()}--[no-]$name');
+      } else {
+        result.write('${separator()}--$name');
+      }
+    }
 
-    return result;
+    if (option.valueHelp != null) result.write('=<${option.valueHelp}>');
+
+    return result.toString();
   }
 
   String _mandatoryOption(Option option) {

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -87,8 +87,24 @@ void main() {
           ''');
     });
 
-    test('verify that aliases are shown for options', () {
+    test('verify that aliases are not shown for options by default', () {
       var parser = ArgParser();
+      parser.addOption('feed',
+          aliases: ['food', 'foodstuff'], help: 'Preferred food');
+      parser.addFlag('zebra', help: 'First');
+      parser.addFlag('monkey', help: 'Second', aliases: ['primate']);
+      parser.addFlag('wombat', help: 'Third');
+
+      validateUsage(parser, '''
+          --feed           Preferred food
+          --[no-]zebra     First
+          --[no-]monkey    Second
+          --[no-]wombat    Third
+          ''');
+    });
+
+    test('verify that aliases shown for options if requested', () {
+      var parser = ArgParser(showAliasesInUsage: true);
       parser.addOption('feed',
           aliases: ['food', 'foodstuff'], help: 'Preferred food');
       parser.addFlag('zebra', help: 'First');

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -87,6 +87,22 @@ void main() {
           ''');
     });
 
+    test('verify that aliases are shown for options', () {
+      var parser = ArgParser();
+      parser.addOption('feed',
+          aliases: ['food', 'foodstuff'], help: 'Preferred food');
+      parser.addFlag('zebra', help: 'First');
+      parser.addFlag('monkey', help: 'Second', aliases: ['primate']);
+      parser.addFlag('wombat', help: 'Third');
+
+      validateUsage(parser, '''
+          --feed,--food,--foodstuff       Preferred food
+          --[no-]zebra                    First
+          --[no-]monkey,--[no-]primate    Second
+          --[no-]wombat                   Third
+          ''');
+    });
+
     test('the default value for a flag is shown if on', () {
       var parser = ArgParser();
       parser.addFlag('affirm', help: 'Should be on', defaultsTo: true);


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

**What I did**
- Add a flag to allow option alias(es) to be output by ArgParser's usage
- The default behaviour remains the same - i.e. aliases are not printed in usage
- Kind of like what is requested in https://github.com/dart-lang/args/issues/240 but for ArgParsers' Options, not CommandRunners' Commands

**How I did it**
- usage_test.dart:
  - Add a test to verify that aliases are shown for options if requested
  - Add a test to verify that aliases are not shown for options by default
- usage.dart: make _longOption also show aliases, if any, if showAliases is true
- added showAliases parameters in various places so that we can preserve current behaviour as default
- updated CHANGELOG.md
