### PR TITLE
Add `mandatory` parameter to `addMultiOption`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.1-wip
 
 * Require Dart 3.3
+* Add `mandatory` parameter to `addMultiOption` method.
 
 ## 2.5.0
 

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -69,6 +69,7 @@ class AllowAnythingParser implements ArgParser {
       Iterable<String>? defaultsTo,
       void Function(List<String>)? callback,
       bool splitCommas = true,
+      bool mandatory = false,
       bool hide = false,
       List<String> aliases = const []}) {
     throw UnsupportedError(

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -267,7 +267,7 @@ class ArgParser {
         valueHelp,
         allowed,
         allowedHelp,
-        defaultsTo?.toList() ?? <String>[],
+        mandatory ? defaultsTo?.toList() : (defaultsTo?.toList() ?? <String>[]),
         callback == null ? null : (List<String> value) => callback(value),
         OptionType.multiple,
         splitCommas: splitCommas,

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -236,6 +236,9 @@ class ArgParser {
   /// If [splitCommas] is `true` (the default), multiple options may be passed
   /// by writing `--option a,b` in addition to `--option a --option b`.
   ///
+  /// If [mandatory] is true and a value is not provided, an [ArgumentError]
+  /// will be thrown.
+  ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
@@ -254,6 +257,7 @@ class ArgParser {
       Iterable<String>? defaultsTo,
       void Function(List<String>)? callback,
       bool splitCommas = true,
+      bool mandatory = false,
       bool hide = false,
       List<String> aliases = const []}) {
     _addOption(
@@ -267,6 +271,7 @@ class ArgParser {
         callback == null ? null : (List<String> value) => callback(value),
         OptionType.multiple,
         splitCommas: splitCommas,
+        mandatory: mandatory,
         hide: hide,
         aliases: aliases);
   }

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -741,6 +741,18 @@ Run "test help" to see global options.'''));
     expect(await runner.run([subcommand.name, '--mandatory-option', 'foo']),
         'foo');
   });
+
+  test('mandatory multi-options in commands', () async {
+    var subcommand = _MandatoryMultiOptionCommand();
+    runner.addCommand(subcommand);
+    expect(
+        () => runner.run([subcommand.name]),
+        throwsA(isA<ArgumentError>().having((e) => e.message, 'message',
+            contains('Option mandatory-multi-option is mandatory'))));
+    expect(
+        await runner.run([subcommand.name, '--mandatory-multi-option', 'foo']),
+        ['foo']);
+  });
 }
 
 class _MandatoryOptionCommand extends Command {
@@ -756,4 +768,19 @@ class _MandatoryOptionCommand extends Command {
 
   @override
   String run() => argResults!['mandatory-option'] as String;
+}
+
+class _MandatoryMultiOptionCommand extends Command {
+  _MandatoryMultiOptionCommand() {
+    argParser.addMultiOption('mandatory-multi-option', mandatory: true);
+  }
+
+  @override
+  String get description => 'A command with a mandatory multi-option';
+
+  @override
+  String get name => 'mandatory-multi-option-command';
+
+  @override
+  List<String> run() => argResults!['mandatory-multi-option'] as List<String>;
 }


### PR DESCRIPTION
Adds a `mandatory` parameter to the `addMultiOption` method to indicate that a value (or values) must be provided by the user. This matches the existing behavior of `addOption`'s `mandatory` parameter and does not change the default behavior of `addMultiOption`.

I did not bump the version in the pubspec as it's currently on a WIP version, please let me know if this was incorrect.

Fixes https://github.com/dart-lang/args/issues/272

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
