### PR TITLE
docs: add comment about Option's mandatory attribute

### DIFF
--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -180,6 +180,10 @@ class ArgParser {
   /// often surprising, and its use is discouraged in favor of reading values
   /// from the [ArgResults].
   ///
+  /// If [mandatory] is `true` an exception will be thrown when this option is
+  /// accessed but not set. If this option is not set and not accessed, no 
+  /// exception is thrown.
+  ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These


### PR DESCRIPTION
Add a short comment about the workings of the `mandatory` attribute of `addOption` which would help clarify when the `mandatory` attribute is enforced.

This comment is based on the description provided [here](https://github.com/dart-lang/args/pull/196#issuecomment-857287859).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
