### PR TITLE
Added arg argument when throwing a `ArgParserException`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.5.1-wip
+## 2.6.0-wip
 
 * Added source argument when throwing a `ArgParserException`.
 * Fix inconsistent `FormatException` messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.5.1-wip
 
 * Added source argument when throwing a `ArgParserException`.
+* Fix inconsistent `FormatException` messages
 * Require Dart 3.3
 
 ## 2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.5.1-wip
 
+* Added source argument when throwing a `ArgParserException`.
 * Require Dart 3.3
 
 ## 2.5.0

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,6 +9,6 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
-  ArgParserException(super.message, [Iterable<String>? commands])
+  ArgParserException(super.message, super.source, [Iterable<String>? commands])
       : commands = commands == null ? const [] : List.unmodifiable(commands);
 }

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,7 +9,10 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
+  /// The argument that were being parsed when the error was discovered.
+  final String? arg;
+
   ArgParserException(super.message,
-      [Iterable<String>? commands, super.source, super.offset])
+      [Iterable<String>? commands, this.arg, super.source, super.offset])
       : commands = commands == null ? const [] : List.unmodifiable(commands);
 }

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,6 +9,7 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
-  ArgParserException(super.message, super.source, [Iterable<String>? commands])
+  ArgParserException(super.message,
+      [Iterable<String>? commands, super.source, super.offset])
       : commands = commands == null ? const [] : List.unmodifiable(commands);
 }

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,7 +9,7 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
-  /// The argument that were being parsed when the error was discovered.
+  /// The argument name that was being parsed when the error was discovered.
   final String? arg;
 
   ArgParserException(super.message,

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,7 +9,8 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
-  /// The name of the argument that was being parsed when the error was discovered.
+  /// The name of the argument that was being parsed when the error was
+  /// discovered.
   final String? argumentName;
 
   ArgParserException(super.message,

--- a/lib/src/arg_parser_exception.dart
+++ b/lib/src/arg_parser_exception.dart
@@ -9,10 +9,13 @@ class ArgParserException extends FormatException {
   /// This will be empty if the error was on the root parser.
   final List<String> commands;
 
-  /// The argument name that was being parsed when the error was discovered.
-  final String? arg;
+  /// The name of the argument that was being parsed when the error was discovered.
+  final String? argumentName;
 
   ArgParserException(super.message,
-      [Iterable<String>? commands, this.arg, super.source, super.offset])
+      [Iterable<String>? commands,
+      this.argumentName,
+      super.source,
+      super.offset])
       : commands = commands == null ? const [] : List.unmodifiable(commands);
 }

--- a/lib/src/arg_results.dart
+++ b/lib/src/arg_results.dart
@@ -66,7 +66,7 @@ class ArgResults {
   /// > flags, [option] for options, and [multiOption] for multi-options.
   dynamic operator [](String name) {
     if (!_parser.options.containsKey(name)) {
-      throw ArgumentError('Could not find an option named "$name".');
+      throw ArgumentError('Could not find an option named "--$name".');
     }
 
     final option = _parser.options[name]!;
@@ -83,7 +83,7 @@ class ArgResults {
   bool flag(String name) {
     var option = _parser.options[name];
     if (option == null) {
-      throw ArgumentError('Could not find an option named "$name".');
+      throw ArgumentError('Could not find an option named "--$name".');
     }
     if (!option.isFlag) {
       throw ArgumentError('"$name" is not a flag.');
@@ -97,7 +97,7 @@ class ArgResults {
   String? option(String name) {
     var option = _parser.options[name];
     if (option == null) {
-      throw ArgumentError('Could not find an option named "$name".');
+      throw ArgumentError('Could not find an option named "--$name".');
     }
     if (!option.isSingle) {
       throw ArgumentError('"$name" is a multi-option.');
@@ -111,7 +111,7 @@ class ArgResults {
   List<String> multiOption(String name) {
     var option = _parser.options[name];
     if (option == null) {
-      throw ArgumentError('Could not find an option named "$name".');
+      throw ArgumentError('Could not find an option named "--$name".');
     }
     if (!option.isMultiple) {
       throw ArgumentError('"$name" is not a multi-option.');
@@ -143,7 +143,7 @@ class ArgResults {
   /// [name] must be a valid option name in the parser.
   bool wasParsed(String name) {
     if (!_parser.options.containsKey(name)) {
-      throw ArgumentError('Could not find an option named "$name".');
+      throw ArgumentError('Could not find an option named "--$name".');
     }
 
     return _parsed.containsKey(name);

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -74,7 +74,7 @@ class Parser {
           throw ArgParserException(
               error.message,
               [commandName, ...error.commands],
-              error.arg,
+              argumentNameerror.argumentName,
               error.source,
               error.offset);
         }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -71,8 +71,12 @@ class Parser {
         try {
           commandResults = commandParser.parse();
         } on ArgParserException catch (error) {
-          throw ArgParserException(error.message,
-              [commandName, ...error.commands], error.source, error.offset);
+          throw ArgParserException(
+              error.message,
+              [commandName, ...error.commands],
+              error.arg,
+              error.source,
+              error.offset);
         }
 
         // All remaining arguments were passed to command so clear them here.
@@ -119,11 +123,11 @@ class Parser {
   /// Pulls the value for [option] from the second argument in [_args].
   ///
   /// Validates that there is a valid value there.
-  void _readNextArgAsValue(Option option, String source) {
+  void _readNextArgAsValue(Option option, String arg) {
     // Take the option argument from the next command line arg.
-    _validate(_args.isNotEmpty, 'Missing argument for "$source".', source);
+    _validate(_args.isNotEmpty, 'Missing argument for "$arg".', arg);
 
-    _setOption(_results, option, _current, source);
+    _setOption(_results, option, _current, arg);
     _args.removeFirst();
   }
 
@@ -315,19 +319,19 @@ class Parser {
   ///
   /// Throws an [ArgParserException] if [condition] is `false`.
   void _validate(bool condition, String message,
-      [dynamic source, int? offset]) {
+      [String? args, List<String>? source, int? offset]) {
     if (!condition) {
-      throw ArgParserException(message, null, source, offset);
+      throw ArgParserException(message, null, args, source, offset);
     }
   }
 
   /// Validates and stores [value] as the value for [option], which must not be
   /// a flag.
-  void _setOption(Map results, Option option, String value, String source) {
+  void _setOption(Map results, Option option, String value, String arg) {
     assert(!option.isFlag);
 
     if (!option.isMultiple) {
-      _validateAllowed(option, value, source);
+      _validateAllowed(option, value, arg);
       results[option.name] = value;
       return;
     }
@@ -336,11 +340,11 @@ class Parser {
 
     if (option.splitCommas) {
       for (var element in value.split(',')) {
-        _validateAllowed(option, element, source);
+        _validateAllowed(option, element, arg);
         list.add(element);
       }
     } else {
-      _validateAllowed(option, value, source);
+      _validateAllowed(option, value, arg);
       list.add(value);
     }
   }
@@ -353,11 +357,11 @@ class Parser {
   }
 
   /// Validates that [value] is allowed as a value of [option].
-  void _validateAllowed(Option option, String value, String source) {
+  void _validateAllowed(Option option, String value, String arg) {
     if (option.allowed == null) return;
 
     _validate(option.allowed!.contains(value),
-        '"$value" is not an allowed value for option "$source".', source);
+        '"$value" is not an allowed value for option "$arg".', arg);
   }
 }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -71,8 +71,8 @@ class Parser {
         try {
           commandResults = commandParser.parse();
         } on ArgParserException catch (error) {
-          throw ArgParserException(
-              error.message, error.source, [commandName, ...error.commands]);
+          throw ArgParserException(error.message,
+              [commandName, ...error.commands], error.source, error.offset);
         }
 
         // All remaining arguments were passed to command so clear them here.
@@ -102,7 +102,7 @@ class Parser {
       // Check if an option is mandatory and was passed; if not, throw an
       // exception.
       if (option.mandatory && parsedOption == null) {
-        throw ArgParserException('Option $name is mandatory.', name);
+        throw ArgParserException('Option $name is mandatory.', null, name);
       }
 
       // ignore: avoid_dynamic_calls
@@ -313,9 +313,10 @@ class Parser {
   /// Called during parsing to validate the arguments.
   ///
   /// Throws an [ArgParserException] if [condition] is `false`.
-  void _validate(bool condition, String message, String source) {
+  void _validate(bool condition, String message,
+      [dynamic source, int? offset]) {
     if (!condition) {
-      throw ArgParserException(message, source);
+      throw ArgParserException(message, null, source, offset);
     }
   }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -74,7 +74,7 @@ class Parser {
           throw ArgParserException(
               error.message,
               [commandName, ...error.commands],
-              argumentNameerror.argumentName,
+              error.argumentName,
               error.source,
               error.offset);
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.5.1-wip
+version: 2.6.0-wip
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.

--- a/test/command_parse_test.dart
+++ b/test/command_parse_test.dart
@@ -139,7 +139,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path', abbr: 'p');
 
-      throwsArgParserException(parser, ['-p', 'foo', 'install'], '-p');
+      throwsFormat(parser, ['-p', 'foo', 'install']);
     });
 
     test('does not parse a command option before the command', () {
@@ -147,7 +147,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path');
 
-      throwsArgParserException(parser, ['--path', 'foo', 'install'], '--path');
+      throwsFormat(parser, ['--path', 'foo', 'install']);
     });
 
     test('does not parse a command abbreviation before the command', () {
@@ -156,7 +156,7 @@ void main() {
       command.addFlag('debug', abbr: 'd');
       command.addFlag('verbose', abbr: 'v');
 
-      throwsArgParserException(parser, ['-dv', 'install'], '-d');
+      throwsFormat(parser, ['-dv', 'install']);
     });
 
     test('assigns collapsed options to the proper command', () {

--- a/test/command_parse_test.dart
+++ b/test/command_parse_test.dart
@@ -139,7 +139,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path', abbr: 'p');
 
-      throwsFormat(parser, ['-p', 'foo', 'install']);
+      throwsArgParserException(parser, ['-p', 'foo', 'install']);
     });
 
     test('does not parse a command option before the command', () {
@@ -147,7 +147,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path');
 
-      throwsFormat(parser, ['--path', 'foo', 'install']);
+      throwsArgParserException(parser, ['--path', 'foo', 'install']);
     });
 
     test('does not parse a command abbreviation before the command', () {
@@ -156,7 +156,7 @@ void main() {
       command.addFlag('debug', abbr: 'd');
       command.addFlag('verbose', abbr: 'v');
 
-      throwsFormat(parser, ['-dv', 'install']);
+      throwsArgParserException(parser, ['-dv', 'install']);
     });
 
     test('assigns collapsed options to the proper command', () {

--- a/test/command_parse_test.dart
+++ b/test/command_parse_test.dart
@@ -139,7 +139,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path', abbr: 'p');
 
-      throwsArgParserException(parser, ['-p', 'foo', 'install']);
+      throwsArgParserException(parser, ['-p', 'foo', 'install'], '-p');
     });
 
     test('does not parse a command option before the command', () {
@@ -147,7 +147,7 @@ void main() {
       var command = parser.addCommand('install');
       command.addOption('path');
 
-      throwsArgParserException(parser, ['--path', 'foo', 'install']);
+      throwsArgParserException(parser, ['--path', 'foo', 'install'], '--path');
     });
 
     test('does not parse a command abbreviation before the command', () {
@@ -156,7 +156,7 @@ void main() {
       command.addFlag('debug', abbr: 'd');
       command.addFlag('verbose', abbr: 'v');
 
-      throwsArgParserException(parser, ['-dv', 'install']);
+      throwsArgParserException(parser, ['-dv', 'install'], '-d');
     });
 
     test('assigns collapsed options to the proper command', () {

--- a/test/command_runner_test.dart
+++ b/test/command_runner_test.dart
@@ -583,7 +583,7 @@ Run "test help" to see global options.
         expect(
             runner.run(['--asdf']),
             throwsUsageException(
-                'Could not find an option named "asdf".', _defaultUsage));
+                'Could not find an option named "--asdf".', _defaultUsage));
       });
 
       test('for a command throws the command usage', () {
@@ -591,7 +591,7 @@ Run "test help" to see global options.
         runner.addCommand(command);
 
         expect(runner.run(['foo', '--asdf']),
-            throwsUsageException('Could not find an option named "asdf".', '''
+            throwsUsageException('Could not find an option named "--asdf".', '''
 Usage: test foo [arguments]
 -h, --help    Print this usage information.
 
@@ -616,7 +616,7 @@ Also, footer!'''));
     test('includes the footer in usage errors', () {
       expect(
           runner.run(['--bad']),
-          throwsUsageException('Could not find an option named "bad".',
+          throwsUsageException('Could not find an option named "--bad".',
               '$_defaultUsage\nAlso, footer!'));
     });
   });
@@ -652,7 +652,7 @@ newlines properly.'''));
 
     test('includes the footer in usage errors', () {
       expect(runner.run(['--bad']),
-          throwsUsageException('Could not find an option named "bad".', '''
+          throwsUsageException('Could not find an option named "--bad".', '''
 Usage: test <command> [arguments]
 
 Global options:
@@ -679,7 +679,7 @@ newlines properly.'''));
       expect(
           runner.run(['--bad']),
           throwsUsageException(
-              'Could not find an option named "bad".', _defaultUsage));
+              'Could not find an option named "--bad".', _defaultUsage));
     });
 
     test("a top-level command doesn't exist", () {

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -50,7 +50,7 @@ void main() {
         var parser = ArgParser();
         parser.addFlag('verbose');
 
-        throwsArgParserException(parser, ['--verbose=true']);
+        throwsArgParserException(parser, ['--verbose=true'], '--verbose');
       });
 
       test('are case-sensitive', () {
@@ -189,7 +189,7 @@ void main() {
         var parser = ArgParser();
         parser.addFlag('strum', negatable: false);
 
-        throwsArgParserException(parser, ['--no-strum']);
+        throwsArgParserException(parser, ['--no-strum'], '--no-strum');
       });
     });
 
@@ -399,14 +399,14 @@ void main() {
 
       test('throw if unknown', () {
         var parser = ArgParser();
-        throwsArgParserException(parser, ['-f']);
+        throwsArgParserException(parser, ['-f'], '-f');
       });
 
       test('throw if the value is missing', () {
         var parser = ArgParser();
         parser.addOption('file', abbr: 'f');
 
-        throwsArgParserException(parser, ['-f']);
+        throwsArgParserException(parser, ['-f'], '-f');
       });
 
       test('does not throw if the value looks like an option', () {
@@ -424,7 +424,7 @@ void main() {
         var parser = ArgParser();
         parser.addOption('mode', abbr: 'm', allowed: ['debug', 'release']);
 
-        throwsArgParserException(parser, ['-mprofile']);
+        throwsArgParserException(parser, ['-mprofile'], '-m');
       });
 
       group('throw if a comma-separated value is not allowed', () {
@@ -433,7 +433,7 @@ void main() {
           parser
               .addMultiOption('mode', abbr: 'm', allowed: ['debug', 'release']);
 
-          throwsArgParserException(parser, ['-mdebug,profile']);
+          throwsArgParserException(parser, ['-mdebug,profile'], '-m');
         });
       });
 
@@ -443,7 +443,7 @@ void main() {
         parser.addOption('banana', abbr: 'b'); // Takes an argument.
         parser.addFlag('cherry', abbr: 'c');
 
-        throwsArgParserException(parser, ['-abc']);
+        throwsArgParserException(parser, ['-abc'], '-b');
       });
 
       test('throw if it has a value but the option is a flag', () {
@@ -452,7 +452,7 @@ void main() {
         parser.addFlag('banana', abbr: 'b');
 
         // The '?!' means this can only be understood as '--apple b?!c'.
-        throwsArgParserException(parser, ['-ab?!c']);
+        throwsArgParserException(parser, ['-ab?!c'], '-a');
       });
 
       test('are case-sensitive', () {
@@ -496,14 +496,15 @@ void main() {
 
       test('throw if unknown', () {
         var parser = ArgParser();
-        throwsArgParserException(parser, ['--unknown']);
-        throwsArgParserException(parser, ['--nobody']); // Starts with "no".
+        throwsArgParserException(parser, ['--unknown'], '--unknown');
+        throwsArgParserException(
+            parser, ['--nobody'], '--nobody'); // Starts with "no".
       });
 
       test('throw if the arg does not include a value', () {
         var parser = ArgParser();
         parser.addOption('mode');
-        throwsArgParserException(parser, ['--mode']);
+        throwsArgParserException(parser, ['--mode'], '--mode');
       });
 
       test('do not throw if the value looks like an option', () {
@@ -538,7 +539,7 @@ void main() {
       test('throw if the value is not in the allowed set', () {
         var parser = ArgParser();
         parser.addOption('mode', allowed: ['debug', 'release']);
-        throwsArgParserException(parser, ['--mode=profile']);
+        throwsArgParserException(parser, ['--mode=profile'], '--mode');
       });
 
       test('returns last provided value', () {

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -50,7 +50,7 @@ void main() {
         var parser = ArgParser();
         parser.addFlag('verbose');
 
-        throwsFormat(parser, ['--verbose=true']);
+        throwsArgParserException(parser, ['--verbose=true']);
       });
 
       test('are case-sensitive', () {
@@ -189,7 +189,7 @@ void main() {
         var parser = ArgParser();
         parser.addFlag('strum', negatable: false);
 
-        throwsFormat(parser, ['--no-strum']);
+        throwsArgParserException(parser, ['--no-strum']);
       });
     });
 
@@ -399,14 +399,14 @@ void main() {
 
       test('throw if unknown', () {
         var parser = ArgParser();
-        throwsFormat(parser, ['-f']);
+        throwsArgParserException(parser, ['-f']);
       });
 
       test('throw if the value is missing', () {
         var parser = ArgParser();
         parser.addOption('file', abbr: 'f');
 
-        throwsFormat(parser, ['-f']);
+        throwsArgParserException(parser, ['-f']);
       });
 
       test('does not throw if the value looks like an option', () {
@@ -424,7 +424,7 @@ void main() {
         var parser = ArgParser();
         parser.addOption('mode', abbr: 'm', allowed: ['debug', 'release']);
 
-        throwsFormat(parser, ['-mprofile']);
+        throwsArgParserException(parser, ['-mprofile']);
       });
 
       group('throw if a comma-separated value is not allowed', () {
@@ -433,7 +433,7 @@ void main() {
           parser
               .addMultiOption('mode', abbr: 'm', allowed: ['debug', 'release']);
 
-          throwsFormat(parser, ['-mdebug,profile']);
+          throwsArgParserException(parser, ['-mdebug,profile']);
         });
       });
 
@@ -443,7 +443,7 @@ void main() {
         parser.addOption('banana', abbr: 'b'); // Takes an argument.
         parser.addFlag('cherry', abbr: 'c');
 
-        throwsFormat(parser, ['-abc']);
+        throwsArgParserException(parser, ['-abc']);
       });
 
       test('throw if it has a value but the option is a flag', () {
@@ -452,7 +452,7 @@ void main() {
         parser.addFlag('banana', abbr: 'b');
 
         // The '?!' means this can only be understood as '--apple b?!c'.
-        throwsFormat(parser, ['-ab?!c']);
+        throwsArgParserException(parser, ['-ab?!c']);
       });
 
       test('are case-sensitive', () {
@@ -496,14 +496,14 @@ void main() {
 
       test('throw if unknown', () {
         var parser = ArgParser();
-        throwsFormat(parser, ['--unknown']);
-        throwsFormat(parser, ['--nobody']); // Starts with "no".
+        throwsArgParserException(parser, ['--unknown']);
+        throwsArgParserException(parser, ['--nobody']); // Starts with "no".
       });
 
       test('throw if the arg does not include a value', () {
         var parser = ArgParser();
         parser.addOption('mode');
-        throwsFormat(parser, ['--mode']);
+        throwsArgParserException(parser, ['--mode']);
       });
 
       test('do not throw if the value looks like an option', () {
@@ -538,7 +538,7 @@ void main() {
       test('throw if the value is not in the allowed set', () {
         var parser = ArgParser();
         parser.addOption('mode', allowed: ['debug', 'release']);
-        throwsFormat(parser, ['--mode=profile']);
+        throwsArgParserException(parser, ['--mode=profile']);
       });
 
       test('returns last provided value', () {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -343,8 +343,10 @@ void throwsIllegalArg(void Function() function, {String? reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }
 
-void throwsFormat(ArgParser parser, List<String> args) {
-  expect(() => parser.parse(args), throwsFormatException);
+void throwsArgParserException(ArgParser parser, List<String> args,
+    {String? reason}) {
+  expect(() => parser.parse(args), throwsA(isA<ArgParserException>()),
+      reason: reason);
 }
 
 Matcher throwsUsageException(Object? message, Object? usage) =>

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -343,14 +343,13 @@ void throwsIllegalArg(void Function() function, {String? reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }
 
-void throwsArgParserException(
-    ArgParser parser, List<String> args, String? source,
+void throwsArgParserException(ArgParser parser, List<String> args, String? arg,
     {String? reason}) {
   try {
     parser.parse(args);
     fail('Expected an ArgParserException');
   } on ArgParserException catch (e) {
-    expect(e.source, source);
+    expect(e.arg, arg);
   } catch (e) {
     fail('Expected an ArgParserException, but got $e');
   }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -343,10 +343,17 @@ void throwsIllegalArg(void Function() function, {String? reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }
 
-void throwsArgParserException(ArgParser parser, List<String> args,
+void throwsArgParserException(
+    ArgParser parser, List<String> args, String? source,
     {String? reason}) {
-  expect(() => parser.parse(args), throwsA(isA<ArgParserException>()),
-      reason: reason);
+  try {
+    parser.parse(args);
+    fail('Expected an ArgParserException');
+  } on ArgParserException catch (e) {
+    expect(e.source, source);
+  } catch (e) {
+    fail('Expected an ArgParserException, but got $e');
+  }
 }
 
 Matcher throwsUsageException(Object? message, Object? usage) =>

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -356,7 +356,7 @@ void throwsArgParserException(ArgParser parser, List<String> args,
   } on ArgParserException catch (e) {
     expect(e.message, message);
     expect(e.commands, commands);
-    expect(e.arg, arg);
+    expect(e.argumentName, arg);
   } catch (e) {
     fail('Expected an ArgParserException, but got $e');
   }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -343,12 +343,19 @@ void throwsIllegalArg(void Function() function, {String? reason}) {
   expect(function, throwsArgumentError, reason: reason);
 }
 
-void throwsArgParserException(ArgParser parser, List<String> args, String? arg,
-    {String? reason}) {
+void throwsFormat(ArgParser parser, List<String> args, {String? reason}) {
+  expect(() => parser.parse(args), throwsA(isA<FormatException>()),
+      reason: reason);
+}
+
+void throwsArgParserException(ArgParser parser, List<String> args,
+    String message, List<String> commands, String arg) {
   try {
     parser.parse(args);
     fail('Expected an ArgParserException');
   } on ArgParserException catch (e) {
+    expect(e.message, message);
+    expect(e.commands, commands);
     expect(e.arg, arg);
   } catch (e) {
     fail('Expected an ArgParserException, but got $e');

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -5,6 +5,8 @@
 import 'package:args/args.dart';
 import 'package:test/test.dart';
 
+import 'test_utils.dart';
+
 void main() {
   test('allowTrailingOptions defaults to true', () {
     var parser = ArgParser();
@@ -18,7 +20,7 @@ void main() {
     });
 
     void expectThrows(List<String> args) {
-      expect(() => parser.parse(args), throwsFormatException,
+      throwsArgParserException(parser, args,
           reason: 'with allowTrailingOptions: true');
     }
 

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -19,8 +19,8 @@ void main() {
       parser = ArgParser(allowTrailingOptions: true);
     });
 
-    void expectThrows(List<String> args) {
-      throwsArgParserException(parser, args,
+    void expectThrows(List<String> args, String source) {
+      throwsArgParserException(parser, args, source,
           reason: 'with allowTrailingOptions: true');
     }
 
@@ -58,7 +58,7 @@ void main() {
 
     test('throws on a trailing option missing its value', () {
       parser.addOption('opt');
-      expectThrows(['arg', '--opt']);
+      expectThrows(['arg', '--opt'], '--opt');
     });
 
     test('parses a trailing option', () {
@@ -69,16 +69,16 @@ void main() {
     });
 
     test('throws on a trailing unknown flag', () {
-      expectThrows(['arg', '--xflag']);
+      expectThrows(['arg', '--xflag'], '--xflag');
     });
 
     test('throws on a trailing unknown option and value', () {
-      expectThrows(['arg', '--xopt', 'v']);
+      expectThrows(['arg', '--xopt', 'v'], '--xopt');
     });
 
     test('throws on a command', () {
       parser.addCommand('com');
-      expectThrows(['arg', 'com']);
+      expectThrows(['arg', 'com'], 'com');
     });
   });
 

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -19,8 +19,8 @@ void main() {
       parser = ArgParser(allowTrailingOptions: true);
     });
 
-    void expectThrows(List<String> args, String source) {
-      throwsArgParserException(parser, args, source,
+    void expectThrows(List<String> args, String arg) {
+      throwsArgParserException(parser, args, arg,
           reason: 'with allowTrailingOptions: true');
     }
 

--- a/test/trailing_options_test.dart
+++ b/test/trailing_options_test.dart
@@ -20,8 +20,7 @@ void main() {
     });
 
     void expectThrows(List<String> args, String arg) {
-      throwsArgParserException(parser, args, arg,
-          reason: 'with allowTrailingOptions: true');
+      throwsFormat(parser, args, reason: 'with allowTrailingOptions: true');
     }
 
     test('collects non-options in rest', () {


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.


Although ArgParserException inherits from FormatException, the source is always null.
This is a very small fix, but please let me know if testing is needed.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
