### PR TITLE
Add option `hideNegatable` to `ArgParser.flag()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 2.6.0-wip
+## 2.6.0
 
 * Added source argument when throwing a `ArgParserException`.
 * Fix inconsistent `FormatException` messages
 * Require Dart 3.3
+* Added option `hideNegatedUsage` to `ArgParser.flag()` allowing a flag to be
+  `negatable` without showing it in the usage text.
 
 ## 2.5.0
 

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -36,7 +36,7 @@ class AllowAnythingParser implements ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
-      bool hideNegatable = false,
+      bool hideNegatedUsage = false,
       List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addFlag() isn't supported.");

--- a/lib/src/allow_anything_parser.dart
+++ b/lib/src/allow_anything_parser.dart
@@ -36,6 +36,7 @@ class AllowAnythingParser implements ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
+      bool hideNegatable = false,
       List<String> aliases = const []}) {
     throw UnsupportedError(
         "ArgParser.allowAnything().addFlag() isn't supported.");

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -119,6 +119,10 @@ class ArgParser {
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///
+  /// If [hideNegatable] is `true`, the fact that this flag can be negated will
+  /// not be documented in [usage].
+  /// It is an error for [hideNegatable] to be `true` if [negatable] is `false`.
+  ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
   /// aliases will not appear as keys in the [options] map.
   ///
@@ -133,6 +137,7 @@ class ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
+      bool hideNegatable = false,
       List<String> aliases = const []}) {
     _addOption(
         name,
@@ -146,6 +151,7 @@ class ArgParser {
         OptionType.flag,
         negatable: negatable,
         hide: hide,
+        hideNegatable: hideNegatable,
         aliases: aliases);
   }
 
@@ -285,6 +291,7 @@ class ArgParser {
       bool? splitCommas,
       bool mandatory = false,
       bool hide = false,
+      bool hideNegatable = false,
       List<String> aliases = const []}) {
     var allNames = [name, ...aliases];
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
@@ -306,12 +313,19 @@ class ArgParser {
           'The option $name cannot be mandatory and have a default value.');
     }
 
+    if (!negatable && hideNegatable) {
+      throw ArgumentError(
+        'The option $name cannot have `hideNegatable` without being negatable.',
+      );
+    }
+
     var option = newOption(name, abbr, help, valueHelp, allowed, allowedHelp,
         defaultsTo, callback, type,
         negatable: negatable,
         splitCommas: splitCommas,
         mandatory: mandatory,
         hide: hide,
+        hideNegatable: hideNegatable,
         aliases: aliases);
     _options[name] = option;
     _optionsAndSeparators.add(option);

--- a/lib/src/arg_parser.dart
+++ b/lib/src/arg_parser.dart
@@ -119,9 +119,9 @@ class ArgParser {
   ///
   /// If [hide] is `true`, this option won't be included in [usage].
   ///
-  /// If [hideNegatable] is `true`, the fact that this flag can be negated will
+  /// If [hideNegatedUsage] is `true`, the fact that this flag can be negated will
   /// not be documented in [usage].
-  /// It is an error for [hideNegatable] to be `true` if [negatable] is `false`.
+  /// It is an error for [hideNegatedUsage] to be `true` if [negatable] is `false`.
   ///
   /// If [aliases] is provided, these are used as aliases for [name]. These
   /// aliases will not appear as keys in the [options] map.
@@ -137,7 +137,7 @@ class ArgParser {
       bool negatable = true,
       void Function(bool)? callback,
       bool hide = false,
-      bool hideNegatable = false,
+      bool hideNegatedUsage = false,
       List<String> aliases = const []}) {
     _addOption(
         name,
@@ -151,7 +151,7 @@ class ArgParser {
         OptionType.flag,
         negatable: negatable,
         hide: hide,
-        hideNegatable: hideNegatable,
+        hideNegatedUsage: hideNegatedUsage,
         aliases: aliases);
   }
 
@@ -291,7 +291,7 @@ class ArgParser {
       bool? splitCommas,
       bool mandatory = false,
       bool hide = false,
-      bool hideNegatable = false,
+      bool hideNegatedUsage = false,
       List<String> aliases = const []}) {
     var allNames = [name, ...aliases];
     if (allNames.any((name) => findByNameOrAlias(name) != null)) {
@@ -313,9 +313,9 @@ class ArgParser {
           'The option $name cannot be mandatory and have a default value.');
     }
 
-    if (!negatable && hideNegatable) {
+    if (!negatable && hideNegatedUsage) {
       throw ArgumentError(
-        'The option $name cannot have `hideNegatable` without being negatable.',
+        'The option $name cannot have `hideNegatedUsage` without being negatable.',
       );
     }
 
@@ -325,7 +325,7 @@ class ArgParser {
         splitCommas: splitCommas,
         mandatory: mandatory,
         hide: hide,
-        hideNegatable: hideNegatable,
+        hideNegatedUsage: hideNegatedUsage,
         aliases: aliases);
     _options[name] = option;
     _optionsAndSeparators.add(option);

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -20,6 +20,7 @@ Option newOption(
     bool? splitCommas,
     bool mandatory = false,
     bool hide = false,
+    bool hideNegatable = false,
     List<String> aliases = const []}) {
   return Option._(name, abbr, help, valueHelp, allowed, allowedHelp, defaultsTo,
       callback, type,
@@ -27,6 +28,7 @@ Option newOption(
       splitCommas: splitCommas,
       mandatory: mandatory,
       hide: hide,
+      hideNegatable: hideNegatable,
       aliases: aliases);
 }
 
@@ -65,6 +67,11 @@ class Option {
   ///
   /// This is `null` unless [type] is [OptionType.flag].
   final bool? negatable;
+
+  /// Whether to document that this flag is [negatable].
+  ///
+  /// This is `null` unless [type] is [OptionType.flag].
+  final bool? hideNegatable;
 
   /// The callback to invoke with the option's value when the option is parsed.
   final Function? callback;
@@ -108,6 +115,7 @@ class Option {
       bool? splitCommas,
       this.mandatory = false,
       this.hide = false,
+      this.hideNegatable,
       this.aliases = const []})
       : allowed = allowed == null ? null : List.unmodifiable(allowed),
         allowedHelp =

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -20,7 +20,7 @@ Option newOption(
     bool? splitCommas,
     bool mandatory = false,
     bool hide = false,
-    bool hideNegatable = false,
+    bool hideNegatedUsage = false,
     List<String> aliases = const []}) {
   return Option._(name, abbr, help, valueHelp, allowed, allowedHelp, defaultsTo,
       callback, type,
@@ -28,7 +28,7 @@ Option newOption(
       splitCommas: splitCommas,
       mandatory: mandatory,
       hide: hide,
-      hideNegatable: hideNegatable,
+      hideNegatedUsage: hideNegatedUsage,
       aliases: aliases);
 }
 
@@ -71,7 +71,7 @@ class Option {
   /// Whether to document that this flag is [negatable].
   ///
   /// This is `null` unless [type] is [OptionType.flag].
-  final bool? hideNegatable;
+  final bool? hideNegatedUsage;
 
   /// The callback to invoke with the option's value when the option is parsed.
   final Function? callback;
@@ -115,7 +115,7 @@ class Option {
       bool? splitCommas,
       this.mandatory = false,
       this.hide = false,
-      this.hideNegatable,
+      this.hideNegatedUsage,
       this.aliases = const []})
       : allowed = allowed == null ? null : List.unmodifiable(allowed),
         allowedHelp =

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -121,7 +121,7 @@ class _Usage {
 
   String _longOption(Option option) {
     String result;
-    if (option.negatable! && !option.hideNegatable!) {
+    if (option.negatable! && !option.hideNegatedUsage!) {
       result = '--[no-]${option.name}';
     } else {
       result = '--${option.name}';

--- a/lib/src/usage.dart
+++ b/lib/src/usage.dart
@@ -121,7 +121,7 @@ class _Usage {
 
   String _longOption(Option option) {
     String result;
-    if (option.negatable!) {
+    if (option.negatable! && !option.hideNegatable!) {
       result = '--[no-]${option.name}';
     } else {
       result = '--${option.name}';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: args
-version: 2.6.0-wip
+version: 2.6.0
 description: >-
   Library for defining parsers for parsing raw command-line arguments into a set
   of options and values using GNU and POSIX style options.

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -16,9 +16,10 @@ void main() {
           ''');
     });
 
-    test('negatable flags with hideNegatable don\'t show "no-" in title', () {
+    test('negatable flags with hideNegatedUsage don\'t show "no-" in title',
+        () {
       var parser = ArgParser();
-      parser.addFlag('mode', help: 'The mode', hideNegatable: true);
+      parser.addFlag('mode', help: 'The mode', hideNegatedUsage: true);
 
       validateUsage(parser, '''
           --mode    The mode

--- a/test/usage_test.dart
+++ b/test/usage_test.dart
@@ -16,6 +16,15 @@ void main() {
           ''');
     });
 
+    test('negatable flags with hideNegatable don\'t show "no-" in title', () {
+      var parser = ArgParser();
+      parser.addFlag('mode', help: 'The mode', hideNegatable: true);
+
+      validateUsage(parser, '''
+          --mode    The mode
+          ''');
+    });
+
     test('non-negatable flags don\'t show "no-" in title', () {
       var parser = ArgParser();
       parser.addFlag('mode', negatable: false, help: 'The mode');


### PR DESCRIPTION
This can be useful when you want to allow negating a flag for eg. future compatibility.

But you don't want to encumber the `--help` text with this information